### PR TITLE
Remove check for Linux.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Permissions.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Permissions.pm
@@ -39,8 +39,6 @@ sub generate_advice {
 sub _check_for_unsafe_permissions {
     my ($self) = @_;
 
-    return if ( $^O ne 'linux' );
-
     my %test_files = (
         '/etc/shadow' => { 'perms' => [ 0200, 0600 ], 'uid' => 0, 'gid' => 0 },
         '/etc/passwd' => { 'perms' => [0644], 'uid' => 0, 'gid' => 0 }


### PR DESCRIPTION
cPanel & WHM has not supported BSD since 11.30, which is far out of support.
Also, if checks for non-Linux were expected, there would have to be far more
scattered throughout the code.  Remove the check for Linux, since it is
clearly not needed.
