### PR TITLE
Uses Kernel Version Number Rather Than Build Time

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -33,7 +33,7 @@ use Cpanel::OSSys           ();
 use Cpanel::OSSys::Env      ();
 
 sub version {
-    return '1.01.2';
+    return '1.01.3';
 }
 
 sub generate_advice {
@@ -124,14 +124,20 @@ sub kernel_updates {
 sub installed_kernels {
     my %installed_kernels;
     my $recent_kernel;
+    my $versionNumber;
     my $recent_buildtime = 0;
     my @args             = ( 'rpm', '-qa', '--queryformat', '%{NAME} %{VERSION}-%{RELEASE} %{BUILDTIME}\n', 'kernel' );
     my @rpm_response     = Cpanel::SafeRun::Errors::saferunnoerror(@args);
     if (@rpm_response) {
         foreach my $version_check (@rpm_response) {
             my ( $rpm, $version, $buildtime ) = split( qr/\s+/, $version_check );
+            # The idea here is to convert the string $VERSION to all numbers
+            # then compare with other installed kernels. This should close
+            # 110893 (internal case) and 6092679 (ticket id).
+            $versionNumber = $version;
+            $versionNumber =~ tr/0-9//cd;
             if ( ($rpm) && ($version) && ( $version =~ m/\d/ ) && ($buildtime) ) {
-                $installed_kernels{$version} = $buildtime;
+                $installed_kernels{$version} = $versionNumber;
             }    # End valid version
         }    # next rpm and version to check
     }    # end of if rpm_response


### PR DESCRIPTION
This patch uses the kernel version number, as given from RPM's query format
VERSION, to determine if a system is running the latest kernel.

The assumption currently present, using BUILDTIME, produces a bug where the
kernel BUILDTIME is older than another kernel. This is the case for
CloudLinux's LVE kernel. Example below:

Build Time   Human Readable Build Time   Kernel Version
1361497318   Thu Feb 21 18:41:58 2013    2.6.32-358.el6
1418905806   Thu Dec 18 05:30:06 2014    2.6.32-531.29.2.lve1.3.11.1.el6
1422484267   Wed Jan 28 15:31:07 2015    2.6.32-504.8.1.el6

This was brought up (by me) in Ticket ID: 6092679 and already found in
internal case: 110893. Tested and built on cPanel 11.48.0.11

Signed-off-by: Adam Brenner <aebrenne@uci.edu>