### PR TITLE
Fix detection of CloudLinux kernels.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors.pm
@@ -158,7 +158,7 @@ sub get_running_kernel_type {
 
     my $redhat_release = Cpanel::LoadFile::loadfile('/etc/redhat-release');
     my $kernel_type =
-        ( ( $kallsyms =~ /\[lve\]/ ) && ( $redhat_release =~ /CloudLinux/ ) ) ? 'cloudlinux'
+        ( ( $kallsyms =~ /\[(kmod)?lve\]/ ) && ( $redhat_release =~ /CloudLinux/ ) ) ? 'cloudlinux'
       : ( $kallsyms =~ /grsec/ ) ? 'grsec'
       : ( -e '/etc/redhat-release' ) ? 'other'
       :                                '';


### PR DESCRIPTION
Case CPANEL-3865: The CloudLinux kernel's lve module changed its name to
kmodlve.  Look for either one of these module names.

Note that querying /etc/redhat-release is not enough to determine
whether the kernel is a CloudLinux kernel, since it's possible to run
CloudLinux on a CentOS kernel, which can happen (usually by accident) in
some configurations.