### PR TITLE
Always notify unjailed users in the same order

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Jail.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Jail.pm
@@ -79,6 +79,7 @@ sub _check_for_unjailed_users {
             }
         }
 
+        @users_without_jail = sort @users_without_jail; # Always notify in the same order
         if ( scalar @users_without_jail > 100 ) {
             splice( @users_without_jail, 100 );
             push @users_without_jail, '..truncated..';


### PR DESCRIPTION
This prevents the tool cobra is working on from sending a
notification every night even when nothing has changed.