### PR TITLE
Accommodate KernelCare output change

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -137,7 +137,7 @@ sub kernel_updates {
         $release = ( split( /:/, $yum_response[$element] ) )[1] if ( ( $yum_response[$element] =~ m/^Release/ ) );
         if ( ( ($rpm) && ($arch) && ($version) && ($release) ) ) {
             s/\s//g foreach ( $rpm, $arch, $version, $release );
-            if ( $kc_kernelversion ne ( $version . "-" . $release . "." . $arch ) ) {
+            if ( $kc_kernelversion ne ( $version . "-" . $release . "." . $arch ) && $kc_kernelversion ne ( $version . "-" . $release ) ) {
                 $kernel_update{ $rpm . " " . $version . "-" . $release } = $version . "-" . $release . "." . $arch;
                 $rpm                                                     = undef;
                 $arch                                                    = undef;


### PR DESCRIPTION
KernelCare version 2.5-4 apparently doesn't include the processor architecture
in the "kcarectl --uname" output. This change should accommodate both.