### PR TITLE
Ensure module names are correctly displayed.

### DIFF
--- a/pkg/Cpanel/Security/Advisor.pm
+++ b/pkg/Cpanel/Security/Advisor.pm
@@ -130,11 +130,17 @@ sub _internal_message {
 sub add_advice {
     my ( $self, $advice ) = @_;
 
-    my $caller = ( caller(1) )[3];
-    $caller =~ /(.+)::([^:]+)$/;
-
-    my $module   = $1;
-    my $function = $2;
+    # Some assessor modules call methods directly on instances of this class,
+    # and some use wrapper methods, so try to figure out the module name
+    # regardless of which path we took.
+    my ( $module, $function );
+    foreach my $level ( 1, 3 ) {
+        my $caller = ( caller($level) )[3];
+        if ( $caller =~ /(Cpanel::Security::Advisor::Assessors::.+)::([^:]+)$/ ) {
+            ( $module, $function ) = ( $1, $2 );
+            last;
+        }
+    }
 
     $self->expand_advice_maketext($advice);
     $self->{'comet'}->add_message(


### PR DESCRIPTION
Case CPANEL-6109: There are two ways for an assessor module to provide
advice: call a method on the security advisor object, or call a method
on $self that wraps the method on the security advisor object.  If the
latter case occurred, the lookup for the function which called us would
always produce something in the Cpanel::Security::Advisor::Assessors
package.

The right way to solve this would be to inspect the class of the $self
object whose method called us, but that isn't possible.  Instead, look
for a specific module pattern either 1 or 3 steps back (to ignore the 2
levels of helper functions) and take that as the module name.