### PR TITLE
Revert the Kernel Care promotion from Security Advisor.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -1,6 +1,6 @@
 package Cpanel::Security::Advisor::Assessors::Kernel;
 
-# Copyright (c) 2016, cPanel, Inc.
+# Copyright (c) 2014, cPanel, Inc.
 # All rights reserved.
 # http://cpanel.net
 #
@@ -35,54 +35,14 @@ use Cpanel::OSSys::Env      ();
 my $kc_kernelversion = kcare_kernel_version("uname");
 
 sub version {
-    return '1.03';
+    return '1.02';
 }
 
 sub generate_advice {
     my ($self) = @_;
-    $self->_suggest_kernelcare;
     $self->_check_for_kernel_version;
 
     return 1;
-}
-
-sub _suggest_kernelcare {
-    my ($self) = @_;
-
-    my $environment = Cpanel::OSSys::Env::get_envtype();
-    my $companyid   = _get_companyid();
-
-    if ( not -e q{/usr/bin/kcarectl} and not( $environment eq 'virtuozzo' || $environment eq 'lxc' ) ) {
-
-        # if cPanel id detected, offer link
-        if ( $companyid eq q{7} ) {
-            $self->add_info_advice(
-                'text' => ['Upgrade to KernelCare'],
-                'suggestion' => [ 'KernelCare provides an easy, effortless way of keeping your operating system kernel up to date without needing to reboot your server. "[output,url,_1,Upgrade to KernelCare,_2,_3]".', 'https://go.cpanel.net/KernelCare', 'target', '_blank', ],
-            );
-        }
-
-        # else, don't offer link
-        else {
-            $self->add_info_advice(
-                'text'       => ['Upgrade to KernelCare'],
-                'suggestion' => [ 'KernelCare provides an easy, effortless way of keeping your operating system kernel up to date without needing to reboot your server. Please consult with your hosting provider for more information.', ],
-            );
-        }
-    }
-
-    return 1;
-}
-
-# treat cid as a string
-sub _get_companyid {
-    my $companyfile = q{/var/cpanel/companyid};
-    my $cid         = q{};
-    if ( open my $fh, "<", $companyfile ) {
-        $cid = <$fh>;
-        close $fh;
-    }
-    return $cid;
 }
 
 sub _check_for_kernel_version {


### PR DESCRIPTION
Case SWAT-121: Reverting KernelCare suggestion for now until
we are ready to make this advisor more widely available. Below
are the revert details:

Revert "Display KernelCare suggestion based on company id."
This reverts commit 75470e10643aa3bb2fefb1df59582d7f6986e759.

Revert "Promote KernelCare if not installed."
This reverts commit 59410f93fefb37983a52f43a66cfe60f3be1108d.