### PR TITLE
Added preliminary message keys.

### DIFF
--- a/pkg/Cpanel/Security/Advisor.pm
+++ b/pkg/Cpanel/Security/Advisor.pm
@@ -71,6 +71,13 @@ our $ADVISE_INFO = 2;
 our $ADVISE_WARN = 4;
 our $ADVISE_BAD  = 8;
 
+our $ADVISE_TYPES_LOOKUP = {
+    1 => q{ADVISE_GOOD},
+    2 => q{ADVISE_INFO},
+    4 => q{ADVISE_WARN},
+    8 => q{ADVISE_BAD},
+};
+
 =head1 ADVISE TYPES
 
 =head2 ADVISE_GOOD

--- a/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
@@ -63,6 +63,7 @@ sub _check_for_apache_chroot {
     if ( $security_advisor_obj->{'cpconf'}->{'jailapache'} ) {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Apache_jailed_apache_is_enabled',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['Jailed Apache is enabled'],
             }
@@ -71,6 +72,7 @@ sub _check_for_apache_chroot {
     elsif ( -x '/usr/bin/cagefsctl' || -x '/usr/sbin/cagefsctl' ) {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Apache_cagefs_is_enabled',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['CageFS is enabled'],
             }
@@ -80,6 +82,7 @@ sub _check_for_apache_chroot {
 
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Apache_vhosts_not_segmented',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['Apache vhosts are not segmented or chroot()ed.'],
                 'suggestion' => [
@@ -119,6 +122,7 @@ sub _check_for_easyapache_build {
     if ( $latest_ea3_version && $installed_version && $latest_ea3_version ne $installed_version ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Apache_easyapache3_updates_available',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_WARN,
                 'text'       => ['EasyApache3 has updates available.'],
                 'suggestion' => [
@@ -141,6 +145,7 @@ sub _check_for_eol_apache {
     if ( $apache_version =~ /^(1\.3|2\.0)/ ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Apache_is_eol',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['Your Apache version is EOL (End of Life)'],
                 'suggestion' => [
@@ -191,6 +196,7 @@ sub _centos_symlink_protection {
         if ($jailedapache) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'  => 'Apache_symlink_protection_enabled',
                     'type' => $good,
                     'text' => ['Apache Symlink Protection is enabled'],
                 }
@@ -199,9 +205,10 @@ sub _centos_symlink_protection {
         else {
             $security_advisor_obj->add_advice(
                 {
-                    type       => $info,
-                    text       => ['Apache Symlink Protection: mod_ruid2 loaded in Apache'],
-                    suggestion => [
+                    'key'        => 'Apache_mod_ruid2_is_loaded',
+                    'type'       => $info,
+                    'text'       => ['Apache Symlink Protection: mod_ruid2 loaded in Apache'],
+                    'suggestion' => [
                         "mod_ruid2 is enabled in Apache. To ensure that this aids in protecting from symlink attacks, Jailed Apache needs to be enabled. If this not set properly, you should see an indication in Security Advisor (this page) in the sections for “Apache vhosts are not segmented or chroot()ed” and “Users running outside of the jail”. If those are not present, your users should be properly jailed. Review [output,url,_1,Symlink Race Condition Protection,_2,_3] for further information.",
                         'http://docs.cpanel.net/twiki/bin/view/EasyApache/Apache/SymlinkPatch',
                         'target',
@@ -214,9 +221,10 @@ sub _centos_symlink_protection {
     if ($bluehost) {
         $security_advisor_obj->add_advice(
             {
-                type       => $warn,
-                text       => ['Apache Symlink Protection: the Bluehost provided Apache patch is in effect'],
-                suggestion => [
+                'key'        => 'Apache_bluehost_provided_symlink_protection',
+                'type'       => $warn,
+                'text'       => ['Apache Symlink Protection: the Bluehost provided Apache patch is in effect'],
+                'suggestion' => [
                     "It appears that the Bluehost provided Apache patch is being used to provide symlink protection. This is less than optimal. Please review [output,url,_1,Symlink Race Condition Protection,_2,_3].",
                     'http://docs.cpanel.net/twiki/bin/view/EasyApache/Apache/SymlinkPatch',
                     'target',
@@ -228,9 +236,10 @@ sub _centos_symlink_protection {
     if ($rack911) {
         $security_advisor_obj->add_advice(
             {
-                type       => $warn,
-                text       => ['Apache Symlink Protection: the Rack911 provided Apache patch is in effect'],
-                suggestion => [
+                'key'        => 'Apache_rack911_provided_symlink_protection',
+                'type'       => $warn,
+                'text'       => ['Apache Symlink Protection: the Rack911 provided Apache patch is in effect'],
+                'suggestion' => [
                     "It appears that the Rack911 provided Apache patch is being used to provide symlink protection. This is less than optimal. Please review [output,url,_1,Symlink Race Condition Protection,_2,_3].",
                     'http://docs.cpanel.net/twiki/bin/view/EasyApache/Apache/SymlinkPatch',
                     'target',
@@ -242,9 +251,10 @@ sub _centos_symlink_protection {
     if ( !($ruid) && !($rack911) && !($bluehost) ) {
         $security_advisor_obj->add_advice(
             {
-                type       => $bad,
-                text       => ['No symlink protection detected'],
-                suggestion => [
+                'key'        => 'Apache_no_symlink_protection',
+                'type'       => $bad,
+                'text'       => ['No symlink protection detected'],
+                'suggestion' => [
                     'You do not appear to have any symlink protection enabled on this server. You can protect against this in multiple ways. Please review the following [output,url,_1,documentation,_2,_3] to find a solution that is suited to your needs.',
                     'http://docs.cpanel.net/twiki/bin/view/EasyApache/Apache/SymlinkPatch',
                     'target',
@@ -282,9 +292,10 @@ sub _cloudlinux_symlink_protection {
         if ( $uncaged_user_count > 0 ) {
             $security_advisor_obj->add_advice(
                 {
-                    type       => $warn,
-                    text       => ['Apache Symlink Protection: Users with CloudLinux CageFS disabled'],
-                    suggestion => [
+                    'key'        => 'Apache_symlink_protection_cagefs_disabled',
+                    'type'       => $warn,
+                    'text'       => ['Apache Symlink Protection: Users with CloudLinux CageFS disabled'],
+                    'suggestion' => [
                         "There appear to be users with cagefs disabled on this server. CageFS in combination with other features of Cloudlinux can further increase security. For further information see the [output,url,_1,CageFS Documentation,_2,_3] and the cPanel documentation on [output,url,_4,Symlink Race Condition Protection,_2,_3]. You have [output,strong,_5] uncaged users.",
                         'http://docs.cloudlinux.com/index.html?cagefs.html',
                         'target',
@@ -298,9 +309,10 @@ sub _cloudlinux_symlink_protection {
         elsif ( Cpanel::SafeRun::Simple::saferun( '/etc/init.d/cagefs', 'status' ) !~ /running/ ) {
             $security_advisor_obj->add_advice(
                 {
-                    type       => $warn,
-                    text       => ['Apache Symlink Protection: CloudLinux CageFS is installed but not currently running'],
-                    suggestion => [
+                    'key'        => 'Apache_cagefs_installed_but_not_running',
+                    'type'       => $warn,
+                    'text'       => ['Apache Symlink Protection: CloudLinux CageFS is installed but not currently running'],
+                    'suggestion' => [
                         "CageFS appears to be installed but is not currently running. CageFS adds filesystem level security to your users by isolating their filesystems from each other and many other parts of the system. You can start CageFS at the command line with “/etc/init.d/cagefs start”. For further information, see the [output,url,_1,CageFS Documentation,_2,_3].",
                         'http://docs.cloudlinux.com/index.html?cagefs.html',
                         'target',
@@ -312,9 +324,10 @@ sub _cloudlinux_symlink_protection {
         else {
             $security_advisor_obj->add_advice(
                 {
-                    type       => $good,
-                    text       => ['Apache Symlink Protection: Cloudlinux CageFS protections are in effect'],
-                    suggestion => ['You are running CageFS. This provides filesystem level protections for your users and server.']
+                    'key'        => 'Apache_cagefs_running',
+                    'type'       => $good,
+                    'text'       => ['Apache Symlink Protection: Cloudlinux CageFS protections are in effect'],
+                    'suggestion' => ['You are running CageFS. This provides filesystem level protections for your users and server.']
 
                 }
             );
@@ -323,9 +336,10 @@ sub _cloudlinux_symlink_protection {
     if ( ($ruid) && ( ( $sysctl_fs_enforce_symlinksifowner !~ /1|2/ ) || ( $sysctl_fs_symlinkown_gid != 99 ) ) ) {
         $security_advisor_obj->add_advice(
             {
-                type       => $bad,
-                text       => ['Apache Symlink Protection: Problems with CloudLinux sysctl settings'],
-                suggestion => [
+                'key'        => 'Apache_sysctl_problems_2',
+                'type'       => $bad,
+                'text'       => ['Apache Symlink Protection: Problems with CloudLinux sysctl settings'],
+                'suggestion' => [
                     "Your sysctl values appear to not be set appropriately for your Apache configuration. To resolve this, please see the documentation on [output,url,_1,SecureLinks,_2,_3]",
                     'http://docs.cloudlinux.com/index.html?securelinks.html',
                     'target',
@@ -337,9 +351,10 @@ sub _cloudlinux_symlink_protection {
     elsif ( !($ruid) && ( ( $sysctl_fs_enforce_symlinksifowner != 1 ) || ( $sysctl_fs_symlinkown_gid != 99 ) ) ) {
         $security_advisor_obj->add_advice(
             {
-                type       => $bad,
-                text       => ['Apache Symlink Protection: Problems with CloudLinux sysctl settings'],
-                suggestion => [
+                'key'        => 'Apache_sysctl_problems_2',
+                'type'       => $bad,
+                'text'       => ['Apache Symlink Protection: Problems with CloudLinux sysctl settings'],
+                'suggestion' => [
                     "Your sysctl values appear to not be set appropriately for your Apache configuration. To resolve this, please see the documentation on [output,url,_1,SecureLinks,_2,_3]",
                     'http://docs.cloudlinux.com/index.html?securelinks.html',
                     'target',
@@ -351,9 +366,10 @@ sub _cloudlinux_symlink_protection {
     else {
         $security_advisor_obj->add_advice(
             {
-                type       => $good,
-                text       => ['Apache Symlink Protection: CloudLinux protections are in effect.'],
-                suggestion => [
+                'key'        => 'Apache_symlink_protection_in_effect',
+                'type'       => $good,
+                'text'       => ['Apache Symlink Protection: CloudLinux protections are in effect.'],
+                'suggestion' => [
                     "You appear to have sufficient protections from Apache Symlink Attacks. If you have not already, consider increasing protection with [output,url,_1,CageFS,_2,_3]. For further information on symlink attack protection see our [output,url,_4,suggestions,_2,_3] on it.",
                     'http://docs.cloudlinux.com/index.html?cagefs.html',
                     'target',
@@ -381,9 +397,10 @@ sub _grsecurity_symlink_protection {
     if ( ( $sysctl_kernel_grsecurity_symlinkown_gid =~ /unknown/ ) && ( $sysctl_kernel_grsecurity_enforce_symlinksifowner =~ /unknown/ ) ) {
         $security_advisor_obj->add_advice(
             {
-                type       => $warn,
-                text       => ['Apache Symlink Protection: Grsecruity does not have the sysctl option enabled'],
-                suggestion => [
+                'key'        => 'Apache_grsecurity_does_not_have_sysctl_enabeled',
+                'type'       => $warn,
+                'text'       => ['Apache Symlink Protection: Grsecruity does not have the sysctl option enabled'],
+                'suggestion' => [
                     "It appears that the sysctl option may not have been selected for the grsec kernel. Due to this, it is not possible to verify the configuration of symlinkown_gid which is the gid of the Apache user that should not follow symlinks. This is usually 99 on cPanel servers. If you are confident that this is correct and do not wish to be able to easily verify your grsecurity kernel options, then you may disregard this message. Otherwise, please visit the [output,url,_1,Grsecurity Documentation,_2,_3] to learn more about enabling the sysctl option during kernel compilation.",
                     'http://en.wikibooks.org/wiki/Grsecurity/Configuring_and_Installing_grsecurity#Suggestions',
                     'target',
@@ -396,9 +413,10 @@ sub _grsecurity_symlink_protection {
         || ( $sysctl_kernel_grsecurity_enforce_symlinksifowner != 1 ) ) {
         $security_advisor_obj->add_advice(
             {
-                type       => $bad,
-                text       => ['Apache Symlink Protection: Grsecurity sysctl values'],
-                suggestion => [
+                'key'        => 'Apache_grsecurity_sysctl_values',
+                'type'       => $bad,
+                'text'       => ['Apache Symlink Protection: Grsecurity sysctl values'],
+                'suggestion' => [
                     "It seems that your sysctl keys, enforce_symlinksifowner, and symlinkown_gid, may not be configured correctly for a cPanel server. Typically, enforce_symlinksifowner is set to 1, and symlinkown_gid is set to 99 on a cPanel server. For further information, see the [output,url,_1,Grsecurity Documentation,_2,_3].",
                     'http://en.wikibooks.org/wiki/Grsecurity/Appendix/Grsecurity_and_PaX_Configuration_Options#Kernel-enforced_SymlinksIfOwnerMatch',
                     'target',
@@ -410,9 +428,10 @@ sub _grsecurity_symlink_protection {
     else {
         $security_advisor_obj->add_advice(
             {
-                type       => $good,
-                text       => ['Apache Symlink Protection: You are well protected by grsecurity'],
-                suggestion => ["You appear to have sufficient protections from Apache Symlink Attacks"],
+                'key'        => 'Apache_grsecurity_protection_enabled',
+                'type'       => $good,
+                'text'       => ['Apache Symlink Protection: You are well protected by grsecurity'],
+                'suggestion' => ["You appear to have sufficient protections from Apache Symlink Attacks"],
             }
         );
     }

--- a/pkg/Cpanel/Security/Advisor/Assessors/Brute.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Brute.pm
@@ -49,6 +49,7 @@ sub _check_for_brute_force_protection {
     if ($cphulk_enabled) {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Brute_protection_enabled',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['cPHulk Brute Force Protection is enabled.'],
             }
@@ -60,6 +61,7 @@ sub _check_for_brute_force_protection {
             if ( -e "/usr/local/cpanel/whostmgr/docroot/cgi/configserver/csf" ) {
                 $security_advisor_obj->add_advice(
                     {
+                        'key'        => 'Brute_csf_installed_but_disabled_1',
                         'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                         'text'       => ['CSF is installed, but appears to be disabled.'],
                         'suggestion' => [
@@ -74,6 +76,7 @@ sub _check_for_brute_force_protection {
             else {
                 $security_advisor_obj->add_advice(
                     {
+                        'key'        => 'Brute_csf_installed_but_disabled_2',
                         'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                         'text'       => ['CSF is installed, but appears to be disabled.'],
                         'suggestion' => ['Run “csf -e“ from the command line.'],
@@ -84,6 +87,7 @@ sub _check_for_brute_force_protection {
         elsif ( check_lfd_running() ) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'  => 'Brute_csf_installed_lfd_running',
                     'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                     'text' => ['CSF is installed, and LFD is running.'],
                 }
@@ -93,6 +97,7 @@ sub _check_for_brute_force_protection {
             if ( -e "/usr/local/cpanel/whostmgr/docroot/cgi/configserver/csf" ) {
                 $security_advisor_obj->add_advice(
                     {
+                        'key'        => 'Brute_csf_installed_lfd_not_running_1',
                         'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                         'text'       => ['CSF is installed, but LFD is not running.'],
                         'suggestion' => [
@@ -107,6 +112,7 @@ sub _check_for_brute_force_protection {
             else {
                 $security_advisor_obj->add_advice(
                     {
+                        'key'        => 'Brute_csf_installed_lfd_not_running_2',
                         'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                         'text'       => ['CSF is installed, but LFD is not running.'],
                         'suggestion' => ['Run “csf --lfd restart“ from the command line.'],
@@ -118,6 +124,7 @@ sub _check_for_brute_force_protection {
     else {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Brute_force_protection_not_enabled',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['No brute force protection detected'],
                 'suggestion' => [

--- a/pkg/Cpanel/Security/Advisor/Assessors/ClamAV.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/ClamAV.pm
@@ -50,6 +50,7 @@ sub _check_clamav {
     if ( !$self->{clamav}{clamscan}{bin} && !$self->{clamav}{freshclam}{bin} ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'ClamAV_not_installed',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['ClamAV is not installed.'],
                 'suggestion' => [
@@ -62,6 +63,7 @@ sub _check_clamav {
     elsif ( !$self->{clamav}{clamscan}{bin} ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'ClamAV_binary_not_installed',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => [q{ClamAV clamscan binary is not installed.}],
                 'suggestion' => [
@@ -74,6 +76,7 @@ sub _check_clamav {
     elsif ( !$self->{clamav}{freshclam}{bin} ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'ClamAV_freshclam_not_installed',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => [q{ClamAV freshclam binary is not installed.}],
                 'suggestion' => [
@@ -88,6 +91,7 @@ sub _check_clamav {
         if ( $self->{clamav}{clamscan}{version} ne $self->{clamav}{freshclam}{version} ) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'        => 'ClamAV_freshclam_and_clamscan_binaries_different_versions',
                     'type'       => $Cpanel::Security::Advisor::ADVISE_WARN,
                     'text'       => [q{ClamAV freshclam and clamscan binaries are different versions.}],
                     'suggestion' => [

--- a/pkg/Cpanel/Security/Advisor/Assessors/EntropyChat.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/EntropyChat.pm
@@ -46,6 +46,7 @@ sub _check_entropy_chat_enabled {
     if ( Cpanel::RestartSrv::check_service( 'service' => 'entropychat', 'user' => 'nobody' ) ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'EntropyChat_is_running',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['Entropy Chat is running.'],
                 'suggestion' => [
@@ -60,6 +61,7 @@ sub _check_entropy_chat_enabled {
     else {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'EntropyChat_is_disabled',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['Entropy Chat is disabled.'],
             }

--- a/pkg/Cpanel/Security/Advisor/Assessors/Frontpage.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Frontpage.pm
@@ -46,6 +46,7 @@ sub _is_frontpage_installed {
     if ( -e '/usr/local/frontpage/version5.0/bin/owsadm.exe' ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Frontpage_is_installed',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['Frontpage is installed'],
                 'suggestion' => [
@@ -68,6 +69,7 @@ sub _is_frontpage_in_easyapache {
     if ( -e '/usr/local/apache/modules/mod_frontpage.so' || -e '/usr/local/apache/modules/mod_auth_passthrough.so' ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Frontpage_easyapache_includes_module',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['EasyApache includes Microsoft® Frontpage modules'],
                 'suggestion' => [

--- a/pkg/Cpanel/Security/Advisor/Assessors/Iptables.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Iptables.pm
@@ -50,11 +50,10 @@ sub _is_iptables_active {
         if ( $status_check =~ m/not running/i ) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'        => 'Iptables_firewall_not_running',
                     'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                     'text'       => ['Firewall is not running'],
-                    'suggestion' => [
-                        'This might be a simple matter of executing "/etc/init.d/iptables start"'
-                    ],
+                    'suggestion' => ['This might be a simple matter of executing "/etc/init.d/iptables start"'],
                 },
             );
         }

--- a/pkg/Cpanel/Security/Advisor/Assessors/Jail.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Jail.pm
@@ -48,6 +48,7 @@ sub _check_for_unjailed_users {
         if ( -e '/var/cpanel/conf/jail/flags/mount_usr_bin_suid' ) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'        => 'Jail_mounted_user_bin_suid',
                     'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                     'text'       => ['Jailshell is mounting /usr/bin suid, which allows escaping the jail via crontab.'],
                     'suggestion' => [
@@ -79,7 +80,7 @@ sub _check_for_unjailed_users {
             }
         }
 
-        @users_without_jail = sort @users_without_jail; # Always notify in the same order
+        @users_without_jail = sort @users_without_jail;    # Always notify in the same order
         if ( scalar @users_without_jail > 100 ) {
             splice( @users_without_jail, 100 );
             push @users_without_jail, '..truncated..';
@@ -88,6 +89,7 @@ sub _check_for_unjailed_users {
         if (@wheel_users) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'        => 'Jail_wheel_users_exist',
                     'type'       => $Cpanel::Security::Advisor::ADVISE_INFO,
                     'text'       => [ 'Users with wheel group access: [list_and,_1].', \@wheel_users ],
                     'suggestion' => [
@@ -103,6 +105,7 @@ sub _check_for_unjailed_users {
         if (@users_without_jail) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'        => 'Jail_users_running_outside_of_jail',
                     'type'       => $Cpanel::Security::Advisor::ADVISE_WARN,
                     'text'       => [ 'Users running outside of the jail: [list_and,_1].', \@users_without_jail ],
                     'suggestion' => [

--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -61,14 +61,21 @@ sub _check_for_kernel_version {
     my $environment           = Cpanel::OSSys::Env::get_envtype();
 
     if ( $running_kernelversion =~ m/\.(?:noarch|x86_64|i.86).+$/ ) {
-        $self->add_info_advice( 'text' => [ 'Custom kernel version cannot be checked to see if it is up to date: [_1]', $running_kernelversion ] );
+        $self->add_info_advice(
+            'key' => 'Kernel_can_not_check',
+            'text' => [ 'Custom kernel version cannot be checked to see if it is up to date: [_1]', $running_kernelversion ]
+        );
     }
     elsif ( ( $environment eq 'virtuozzo' ) || ( $environment eq 'lxc' ) ) {
-        $self->add_info_advice( 'text' => ['Kernel updates are not supported on this virtualization platform. Be sure to keep the host’s kernel up to date.'] );
+        $self->add_info_advice(
+            'key'  => 'Kernel_unsupported_environment',
+            'text' => ['Kernel updates are not supported on this virtualization platform. Be sure to keep the host’s kernel up to date.']
+        );
     }
     elsif ( (@kernel_update) && ($kc_kernelversion) ) {
         if ( kcare_kernel_version("check") eq "New version available" ) {
             $self->add_bad_advice(
+                'key'  => 'Kernel_kernelcare_update_available',
                 'text' => [
                     'Kernel patched with KernelCare, but out of date. running kernel: [_1], most recent kernel: [list_and,_2]',
                     $kc_kernelversion,
@@ -79,6 +86,7 @@ sub _check_for_kernel_version {
         }
         else {
             $self->add_info_advice(
+                'key'  => 'Kernel_waiting_for_kernelcare_update',
                 'text' => [
                     'Kernel patched with KernelCare, but awaiting further updates. running kernel: [_1], most recent kernel: [list_and,_2]',
                     $kc_kernelversion,
@@ -90,6 +98,7 @@ sub _check_for_kernel_version {
     }
     elsif ( (@kernel_update) ) {
         $self->add_bad_advice(
+            'key'  => 'Kernel_outdated',
             'text' => [
                 'Current kernel version is out of date. running kernel: [_1], most recent kernel: [list_and,_2]',
                 $running_kernelversion,
@@ -99,10 +108,11 @@ sub _check_for_kernel_version {
         );
     }
     elsif ($kc_kernelversion) {
-        $self->add_good_advice( 'text' => [ 'KernelCare is installed and current running kernel version is up to date: [_1]', $kc_kernelversion ] );
+        $self->add_good_advice( 'key' => 'Kernel_kernelcare_is_current', 'text' => [ 'KernelCare is installed and current running kernel version is up to date: [_1]', $kc_kernelversion ] );
     }
     elsif ( ( $running_kernelversion ne $boot_kernelversion ) ) {
         $self->add_bad_advice(
+            'key'  => 'Kernel_boot_running_mismatch',
             'text' => [
                 'Current kernel version does not match the kernel version for boot. running kernel: [_1], boot kernel: [_2]',
                 $running_kernelversion,
@@ -118,7 +128,10 @@ sub _check_for_kernel_version {
         );
     }
     else {
-        $self->add_good_advice( 'text' => [ 'Current running kernel version is up to date: [_1]', $running_kernelversion ] );
+        $self->add_good_advice(
+            'key' => 'Kernel_running_is_current',
+            'text' => [ 'Current running kernel version is up to date: [_1]', $running_kernelversion ]
+        );
     }
 
     return 1;

--- a/pkg/Cpanel/Security/Advisor/Assessors/Mysql.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Mysql.pm
@@ -45,6 +45,7 @@ sub generate_advice {
 
     if ( !$self->_sqlcmd('SELECT 1;') ) {
         $self->add_bad_advice(
+            'key'        => 'Mysql_can_not_connect_to_mysql',
             'text'       => ['Cannot connect to MySQL server.'],
             'suggestion' => [
                 'Enable MySQL database service',
@@ -76,12 +77,16 @@ sub _check_for_db_test {
     my $exists = $self->_sqlcmd(qq{show databases like 'test'});
 
     if ( !$exists ) {
-        $self->add_good_advice( text => "MySQL test database doesn't exist." );
+        $self->add_good_advice(
+            'key'  => 'Mysql_test_database_does_not_exist',
+            'text' => "MySQL test database doesn't exist."
+        );
     }
     else {
         $self->add_bad_advice(
-            text       => "MySQL test database exists.",
-            suggestion => q{MySQL test database is used by numerous attacks and should be removed.
+            'key'        => 'Mysql_test_database_exists',
+            'text'       => "MySQL test database exists.",
+            'suggestion' => q{MySQL test database is used by numerous attacks and should be removed.
 				> mysql -e 'drop database test'
 			}
         );
@@ -108,12 +113,16 @@ sub _check_for_anonymous_users {
     }
 
     if ($ok) {
-        $self->add_good_advice( text => "MySQL check for anonymous users" );
+        $self->add_good_advice(
+            'key'  => 'Mysql_no_anonymous_users',
+            'text' => "MySQL check for anonymous users"
+        );
     }
     else {
         $self->add_bad_advice(
-            text       => "You have some anonymous mysql users",
-            suggestion => q{Remove mysql anonymous mysql users: > mysql -e 'drop user ""'}
+            'key'        => 'Mysql_found_anonymous_users',
+            'text'       => "You have some anonymous mysql users",
+            'suggestion' => q{Remove mysql anonymous mysql users: > mysql -e 'drop user ""'}
         );
     }
 
@@ -158,15 +167,22 @@ sub _check_for_public_bind_address {
         my $version = ( Cpanel::IP::Parse::parse($bind_address) )[0];
 
         if ( Cpanel::IP::Loopback::is_loopback($bind_address) ) {
-            $self->add_good_advice( text => "MySQL is listening only on a local address." );
+            $self->add_good_advice(
+                'key'  => 'Mysql_listening_only_to_local_address',
+                'text' => "MySQL is listening only on a local address."
+            );
         }
         elsif ( ( ( $version == 4 ) && @deny_rules && ( ( $bind_address =~ /ffff/i ) ? @deny_rules_6 : 1 ) ) || ( ( $version == 6 ) && @deny_rules_6 ) || ( csf_port_closed($port) ) ) {
-            $self->add_good_advice( text => "The MySQL port is blocked by the firewall, effectively allowing only local connections." );
+            $self->add_good_advice(
+                'key'  => 'Mysql_port_blocked_by_firewall_1',
+                'text' => "The MySQL port is blocked by the firewall, effectively allowing only local connections."
+            );
         }
         else {
             $self->add_bad_advice(
-                text       => "The MySQL service is currently configured to listen on a public address: (bind-address=$bind_address)",
-                suggestion => [
+                'key'        => 'Mysql_listening_on_public_address',
+                'text'       => "The MySQL service is currently configured to listen on a public address: (bind-address=$bind_address)",
+                'suggestion' => [
                     'Configure bind-address=127.0.0.1 in /etc/my.cnf, or close port [_1] in the server’s firewall.',
                     $port
                 ],
@@ -175,12 +191,16 @@ sub _check_for_public_bind_address {
     }
     else {
         if ( ( @deny_rules && @deny_rules_6 ) || ( csf_port_closed($port) ) ) {
-            $self->add_good_advice( text => "The MySQL port is blocked by the firewall, effectively allowing only local connections." );
+            $self->add_good_advice(
+                'key'  => 'Mysql_port_blocked_by_firewall_2',
+                'text' => "The MySQL port is blocked by the firewall, effectively allowing only local connections."
+            );
         }
         else {
             $self->add_bad_advice(
-                text       => 'The MySQL service is currently configured to listen on all interfaces: (bind-address=*)',
-                suggestion => [
+                'key'        => 'Mysql_listening_on_all_interfaces',
+                'text'       => 'The MySQL service is currently configured to listen on all interfaces: (bind-address=*)',
+                'suggestion' => [
                     'Configure bind-address=127.0.0.1 in /etc/my.cnf, or close port [_1] in the server’s firewall.',
                     $port
                 ],

--- a/pkg/Cpanel/Security/Advisor/Assessors/Passwords.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Passwords.pm
@@ -44,6 +44,7 @@ sub _check_for_low_pwstrength {
     if ( !$security_advisor_obj->{'cpconf'}->{'minpwstrength'} || $security_advisor_obj->{'cpconf'}->{'minpwstrength'} < 25 ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Passwords_weak_permitted',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['Trivially weak passwords are permitted.'],
                 'suggestion' => [
@@ -59,6 +60,7 @@ sub _check_for_low_pwstrength {
     elsif ( $security_advisor_obj->{'cpconf'}->{'minpwstrength'} < 50 ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Passwords_strength_requirements_are_low',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_WARN,
                 'text'       => ['Password strength requirements are low.'],
                 'suggestion' => [
@@ -74,6 +76,7 @@ sub _check_for_low_pwstrength {
     elsif ( $security_advisor_obj->{'cpconf'}->{'minpwstrength'} < 65 ) {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Passwords_strength_requirements_are_moderate',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_INFO,
                 'text'       => ['Password strength requirements are moderate.'],
                 'suggestion' => [
@@ -89,6 +92,7 @@ sub _check_for_low_pwstrength {
     else {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Passwords_strengths_requirements_are_strong',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['Password strength requirements are strong.'],
             }

--- a/pkg/Cpanel/Security/Advisor/Assessors/Processes.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Processes.pm
@@ -59,6 +59,7 @@ sub _check_for_outdated_processes {
 
     if ( !$exec ) {
         $self->add_info_advice(
+            'key'      => 'Processes_unable_to_check_running_executables',
             text       => ['Unable to check whether running executables are up-to-date.'],
             suggestion => [ 'Install the ‘[_1]’ command by running ‘[_2]’ on the command line to get notifications when executables are updated but the existing processes are not restarted.', $command, $package_install_cmd ],
         );
@@ -68,6 +69,7 @@ sub _check_for_outdated_processes {
 
         if ( $proc->stdout() ) {
             $self->add_bad_advice(
+                'key'      => 'Processes_detected_running_from_outdated_executables',
                 text       => ['Detected processes that are running outdated binary executables.'],
                 suggestion => [
                     'Reboot the system in the “[output,url,_1,Graceful Server Reboot,_2,_3]” area.  Alternatively, [asis,SSH] into this server and run ‘[_4]’, then manually restart each of the listed processes.',
@@ -80,16 +82,21 @@ sub _check_for_outdated_processes {
         }
         elsif ( $proc->CHILD_ERROR() ) {
             $self->add_warn_advice(
+                'key' => 'Processes_error_while_checking_running_executables_1',
                 text => [ 'An error occurred while attempting to check whether running executables are up-to-date: [_1]', $proc->autopsy() ],
             );
         }
         elsif ( $proc->stderr() ) {
             $self->add_warn_advice(
+                'key' => 'Processes_error_while_checking_running_executables_2',
                 text => [ 'An error occurred while attempting to check whether running executables are up-to-date: [_1]', $proc->stderr() ],
             );
         }
         else {
-            $self->add_good_advice( text => ['No processes with outdated binaries detected.'] );
+            $self->add_good_advice(
+                key  => 'Processes_none_with_outdated_executables',
+                text => ['No processes with outdated binaries detected.']
+            );
         }
     }
 

--- a/pkg/Cpanel/Security/Advisor/Assessors/SSH.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/SSH.pm
@@ -49,6 +49,7 @@ sub _check_for_ssh_settings {
 
     if ( $sshd_config->{'PasswordAuthentication'} =~ m/yes/i || $sshd_config->{'ChallengeResponseAuthentication'} =~ m/yes/i ) {
         $self->add_bad_advice(
+            'key'        => 'SSH_password_authentication_enabled',
             'text'       => ['SSH password authentication is enabled.'],
             'suggestion' => [
                 'Disable SSH password authentication in the “[output,url,_1,SSH Password Authorization Tweak,_2,_3]” area',
@@ -60,6 +61,7 @@ sub _check_for_ssh_settings {
     }
     else {
         $self->add_good_advice(
+            'key'  => 'SSH_password_authentication_disabled',
             'text' => ['SSH password authentication is disabled.'],
         );
 
@@ -67,6 +69,7 @@ sub _check_for_ssh_settings {
 
     if ( $sshd_config->{'PermitRootLogin'} =~ m/yes/i || !$sshd_config->{'PermitRootLogin'} ) {
         $self->add_bad_advice(
+            'key'        => 'SSH_direct_root_login_permitted',
             'text'       => ['SSH direct root logins are permitted.'],
             'suggestion' => [
                 'Manually edit /etc/ssh/sshd_config and change PermitRootLogin to “without-password” or “no”, then restart SSH in the “[output,url,_1,Restart SSH,_2,_3]” area',
@@ -78,6 +81,7 @@ sub _check_for_ssh_settings {
     }
     else {
         $self->add_good_advice(
+            'key'  => 'SSH_direct_root_logins_disabled',
             'text' => ['SSH direct root logins are disabled.'],
         );
 
@@ -99,6 +103,7 @@ sub _check_for_ssh_version {
     if ( length $current_sshversion && length $latest_sshversion ) {
         if ( $current_sshversion lt $latest_sshversion ) {
             $self->add_bad_advice(
+                'key'        => 'SSH_version_outdated',
                 'text'       => ['Current SSH version is out of date.'],
                 'suggestion' => [
                     'Update current system software in the “[output,url,_1,Update System Software,_2,_3]” area',
@@ -109,11 +114,15 @@ sub _check_for_ssh_version {
             );
         }
         else {
-            $self->add_good_advice( 'text' => [ 'Current SSH version is up to date: ' . $current_sshversion ] );
+            $self->add_good_advice(
+                'key'  => 'SSH_is_current',
+                'text' => [ 'Current SSH version is up to date: ' . $current_sshversion ]
+            );
         }
     }
     else {
         $self->add_warn_advice(
+            'key'        => 'SSH_can_not_determine_version',
             'text'       => ['Unable to determine SSH version'],
             'suggestion' => ['Ensure that yum and rpm are working on your system.']
         );

--- a/pkg/Cpanel/Security/Advisor/Assessors/Scgiwrap.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Scgiwrap.pm
@@ -84,6 +84,7 @@ sub _check_scgiwrap {
     if ( $suenabled && !$scgienabled ) {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Scgiwrap_SCGI_is_disabled',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['SCGI is disabled, currently using the recommended suEXEC.'],
             }
@@ -93,6 +94,7 @@ sub _check_scgiwrap {
         if ( !$ruid ) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'        => 'Scgiwrap_SCGI_AND_suEXEC_are_enabled',
                     'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                     'text'       => ['Both SCGI and suEXEC are enabled.'],
                     'suggestion' => [
@@ -107,6 +109,7 @@ sub _check_scgiwrap {
         else {
             $security_advisor_obj->add_advice(
                 {
+                    'key'  => 'Scgiwrap_SCGI_suEXEC_and_mod_ruid2_are_enabled',
                     'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                     'text' => ['SCGI, suEXEC, and mod_ruid2 are enabled.'],
                 }
@@ -117,6 +120,7 @@ sub _check_scgiwrap {
         if ( !$ruid ) {
             $security_advisor_obj->add_advice(
                 {
+                    'key'        => 'Scgiwrap_suEXEC_is_disabled',
                     'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                     'text'       => ['suEXEC is disabled.'],
                     'suggestion' => [
@@ -131,6 +135,7 @@ sub _check_scgiwrap {
         else {
             $security_advisor_obj->add_advice(
                 {
+                    'key'  => 'Scgiwrap_suEXEC_is_disabled_mod_ruid2_is_installed',
                     'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                     'text' => ['suEXEC is disabled; however mod_ruid2 is installed.'],
                 }
@@ -140,6 +145,7 @@ sub _check_scgiwrap {
     else {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Scgiwrap_SCGI_is_enabled',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['SCGI is enabled.'],
                 'suggestion' => [

--- a/pkg/Cpanel/Security/Advisor/Assessors/Spam.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Spam.pm
@@ -46,6 +46,7 @@ sub _check_for_nobody_tracking {
     if ( $security_advisor_obj->{'cpconf'}->{'nobodyspam'} ) {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Spam_user_nobody_can_not_permitted_to_send_email',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['The pseudo-user “nobody” is not permitted to send email.'],
             }
@@ -54,6 +55,7 @@ sub _check_for_nobody_tracking {
     else {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Spam_user_nobody_can_send_email',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['The pseudo-user “nobody” is permitted to send email.'],
                 'suggestion' => [
@@ -69,6 +71,7 @@ sub _check_for_nobody_tracking {
     if ( -e '/var/cpanel/smtpgidonlytweak' ) {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Spam_outbound_smtp_restricted',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['Outbound SMTP connections are restricted.'],
             }
@@ -78,6 +81,7 @@ sub _check_for_nobody_tracking {
     elsif ( _csf_has_option( 'SMTP_BLOCK', '1' ) ) {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Spam_smtp_block_enabled',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['CSF has SMTP_BLOCK enabled.'],
             }
@@ -87,6 +91,7 @@ sub _check_for_nobody_tracking {
     else {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Spam_smtp_unrestricted',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['Outbound SMTP connections are unrestricted.'],
                 'suggestion' => [
@@ -103,6 +108,7 @@ sub _check_for_nobody_tracking {
     if ( -e '/var/cpanel/config/email/query_apache_for_nobody_senders' ) {
         $security_advisor_obj->add_advice(
             {
+                'key'  => 'Spam_apache_queried_for_sender',
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
                 'text' => ['Apache is being queried to determine the actual sender when mail originates from the “nobody” pseudo-user.'],
             }
@@ -111,6 +117,7 @@ sub _check_for_nobody_tracking {
     else {
         $security_advisor_obj->add_advice(
             {
+                'key'        => 'Spam_apache_not_queried_for_sender',
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => ['Apache is not being queried to determine the actual sender when mail originates from the “nobody” pseudo-user.'],
                 'suggestion' => [


### PR DESCRIPTION
This commit adds static keys. They are preceded by the assessor's name (e.g., SSH_ for SSH.pm). There is a bikeshed alert here. I think that while there should be some candid discussion on what the initial set of keys should be, we should not spent much time at all. These and future keys must be globally unique. They will be used to track messages sent, this work is being done internally via SWAT-94.