### PR TITLE
Improve symlink protection message

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
@@ -206,7 +206,7 @@ sub _centos_symlink_protection {
                     'text'       => $self->_lh->maketext('Apache Symlink Protection: mod_ruid2 loaded in Apache'),
                     'suggestion' => $self->_lh->maketext(
                         "mod_ruid2 is enabled in Apache. To ensure that this aids in protecting from symlink attacks, Jailed Apache needs to be enabled. If this not set properly, you should see an indication in Security Advisor (this page) in the sections for “Apache vhosts are not segmented or chroot()ed” and “Users running outside of the jail”. If those are not present, your users should be properly jailed. Review [output,url,_1,Symlink Race Condition Protection,_2,_3] for further information.",
-                        'https://go.cpanel.net/SymlinkPatch',
+                        'https://go.cpanel.net/apachesymlink',
                         'target',
                         '_blank'
                     ),
@@ -222,7 +222,7 @@ sub _centos_symlink_protection {
                 'text'       => $self->_lh->maketext('Apache Symlink Protection: the Bluehost provided Apache patch is in effect'),
                 'suggestion' => $self->_lh->maketext(
                     "It appears that the Bluehost provided Apache patch is being used to provide symlink protection. This is less than optimal. Please review [output,url,_1,Symlink Race Condition Protection,_2,_3].",
-                    'https://go.cpanel.net/SymlinkPatch',
+                    'https://go.cpanel.net/apachesymlink',
                     'target',
                     '_blank'
                 ),
@@ -237,7 +237,7 @@ sub _centos_symlink_protection {
                 'text'       => $self->_lh->maketext('Apache Symlink Protection: the Rack911 provided Apache patch is in effect'),
                 'suggestion' => $self->_lh->maketext(
                     "It appears that the Rack911 provided Apache patch is being used to provide symlink protection. This is less than optimal. Please review [output,url,_1,Symlink Race Condition Protection,_2,_3].",
-                    'https://go.cpanel.net/SymlinkPatch',
+                    'https://go.cpanel.net/apachesymlink',
                     'target',
                     '_blank',
                 ),
@@ -252,7 +252,7 @@ sub _centos_symlink_protection {
                 'text'       => $self->_lh->maketext('No symlink protection detected'),
                 'suggestion' => $self->_lh->maketext(
                     'You do not appear to have any symlink protection enabled on this server. You can protect against this in multiple ways. Please review the following [output,url,_1,documentation,_2,_3] to find a solution that is suited to your needs.',
-                    'https://go.cpanel.net/SymlinkPatch',
+                    'https://go.cpanel.net/apachesymlink',
                     'target',
                     '_blank'
                 ),
@@ -296,7 +296,7 @@ sub _cloudlinux_symlink_protection {
                         'http://docs.cloudlinux.com/index.html?cagefs.html',
                         'target',
                         '_blank',
-                        'https://go.cpanel.net/SymlinkPatch',
+                        'https://go.cpanel.net/apachesymlink',
                         "$uncaged_user_count"
                     ),
                 }
@@ -370,7 +370,7 @@ sub _cloudlinux_symlink_protection {
                     'http://docs.cloudlinux.com/index.html?cagefs.html',
                     'target',
                     '_blank',
-                    'https://go.cpanel.net/SymlinkPatch'
+                    'https://go.cpanel.net/apachesymlink'
                 ),
             }
         );

--- a/pkg/Cpanel/Security/Advisor/Assessors/Symlinks.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Symlinks.pm
@@ -101,7 +101,12 @@ sub _check_for_symlink_kernel_patch {
         $self->add_bad_advice(
             'key'        => q{Symlinks_no_kernel_support_for_ownership_attacks_1},
             'text'       => $self->_lh->maketext('Kernel does not support the prevention of symlink ownership attacks.'),
-            'suggestion' => $self->_lh->maketext('You do not appear to have any symlink protection enabled through a properly patched kernel on this server, which provides additional protect beyond those solutions employed in userland. Please review the following documentation to learn how to apply this protection.'),
+            'suggestion' => $self->_lh->maketext(
+                'You do not appear to have any symlink protection enabled through a properly patched kernel on this server, which provides additional protections beyond those solutions employed in userland. Please review [output,url,_1,the documentation,_2,_3] to learn how to apply this protection.',
+                'https://go.cpanel.net/apachesymlink',
+                'target',
+                '_blank'
+            ),
         );
 
         return 1;
@@ -113,7 +118,12 @@ sub _check_for_symlink_kernel_patch {
         $self->add_bad_advice(
             'key'        => q{Symlinks_no_kernel_support_for_ownership_attacks_2},
             'text'       => $self->_lh->maketext('Kernel does not support the prevention of symlink ownership attacks.'),
-            'suggestion' => $self->_lh->maketext('You do not appear to have any symlink protection enabled through a properly patched kernel on this server, which provides additional protect beyond those solutions employed in userland. Please review the following documentation to learn how to apply this protection.'),
+            'suggestion' => $self->_lh->maketext(
+                'You do not appear to have any symlink protection enabled through a properly patched kernel on this server, which provides additional protections beyond those solutions employed in userland. Please review [output,url,_1,the documentation,_2,_3] to learn how to apply this protection.',
+                'https://go.cpanel.net/apachesymlink',
+                'target',
+                '_blank'
+            ),
         );
 
         return 1;


### PR DESCRIPTION
Fix the symlink protection message to be grammatical and provide a link to the documentation.  Also, address some broken links.