### PR TITLE
Use proper go.cpanel.net link for compromised systems.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Trojans.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Trojans.pm
@@ -88,7 +88,7 @@ sub _check_for_libkeyutils {
                             ),
                             'suggestion' => $self->_lh->maketext(
                                 'Check the following to determine if this server is compromised "[output,url,_1,Determine your Systems Status,_2,_3]"',
-                                'https://go.cpanel.net/CompSystem',
+                                'https://go.cpanel.net/checkyourserver',
                                 'target',
                                 '_blank'
                             ),
@@ -114,7 +114,7 @@ sub _check_for_UMBREON_rootkit {
             'text'       => $self->_lh->maketext("UMBREON rootkit check: Evidence of the UMBREON rootkit was found."),
             'suggestion' => $self->_lh->maketext(
                 'Check the following to determine if this server is compromised "[output,url,_1,Determine your Systems Status,_2,_3]"',
-                'https://go.cpanel.net/CompSystem',
+                'https://go.cpanel.net/checkyourserver',
                 'target',
                 '_blank'
             ),
@@ -146,7 +146,7 @@ sub _check_for_NCOM_rootkit {
             ),
             'suggestion' => $self->_lh->maketext(
                 'Check the following for more information "[output,url,_1,We Live Security More Information,_2,_3]"',
-                'https://go.cpanel.net/CompSystem',
+                'https://go.cpanel.net/checkyourserver',
                 'target',
                 '_blank'
             ),
@@ -164,7 +164,7 @@ sub _check_for_jynx2_rootkit {
             'text'       => $self->_lh->maketext("Jynx 2 rootkit check: Evidence of the Jynx 2 rootkit was found."),
             'suggestion' => $self->_lh->maketext(
                 'Check the following to determine if this server is compromised "[output,url,_1,Determine your Systems Status,_2,_3]"',
-                'https://go.cpanel.net/CompSystem',
+                'https://go.cpanel.net/checkyourserver',
                 'target',
                 '_blank'
             ),


### PR DESCRIPTION
Case CPANEL-9301: The previous go.cpanel.net link didn't point anywhere
useful.  Point the link to a useful documentation page.