### PR TITLE
Properly detect sysctl setting on grsec kernel

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
@@ -408,8 +408,8 @@ sub _grsecurity_symlink_protection {
     my $warn                 = $Cpanel::Security::Advisor::ADVISE_WARN;
     my $bad                  = $Cpanel::Security::Advisor::ADVISE_BAD;
     my ( $sysctl_kernel_grsecurity_symlinkown_gid, $sysctl_kernel_grsecurity_enforce_symlinksifowner ) = (
-        Cpanel::SafeRun::Simple::saferun( 'sysctl', '-n', 'kernel.grsecurity.symlinkown_gid' ),
-        Cpanel::SafeRun::Simple::saferun( 'sysctl', '-n', 'kernel.grsecurity.enforce_symlinksifowner' )
+        Cpanel::SafeRun::Simple::saferunallerrors( 'sysctl', '-n', 'kernel.grsecurity.symlinkown_gid' ),
+        Cpanel::SafeRun::Simple::saferunallerrors( 'sysctl', '-n', 'kernel.grsecurity.enforce_symlinksifowner' )
     );
     if ( ( $sysctl_kernel_grsecurity_symlinkown_gid =~ /unknown/ ) && ( $sysctl_kernel_grsecurity_enforce_symlinksifowner =~ /unknown/ ) ) {
         $security_advisor_obj->add_advice(


### PR DESCRIPTION
On a grsec kernel, if the sysctl option was not enabled, cPanel would indicate that the setting was incorrectly set. This occurred because the word "unknown" was being printed on standard
error, but we only looked for it on standard output.  Capture the error output as well, so we correctly detect when the option is not enabled.

I tested this by forcing the code to think it was a grsec kernel and then running the Security Advisor on a CentOS 6 system.  After this change, it indicates that it's a warning, instead of an error.