### PR TITLE
Rework Kernel assessor to use Cpanel module

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -313,20 +313,36 @@ sub _check_kernelcare_kernel {
         );
     }
     elsif ( $kernel->{update_available} && !$kernel->{update_excluded} ) {
-        my $VRA = "$kernel->{update_available}{version}-$kernel->{update_available}{release}.$kernel->{update_available}{arch}";
-        $self->add_info_advice(
-            'key'  => 'Kernel_waiting_for_kernelcare_update',
-            'text' => $self->_lh->maketext(
-                'The system kernel is at version “[_1]”, but an update is available: [_2]',
-                $kernel->{running_version},
-                $VRA,
-            ),
-            'suggestion' => _make_unordered_list(
-                $self->_lh->maketext('You must take one of the following actions to ensure the system is up-to-date:'),
-                $self->_lh->maketext('Wait a few days for [asis,KernelCare] to publish a kernel patch.'),
-                _msg_update_and_reboot($self),
-            ),
-        );
+        if ( $kernel->{running_latest} ) {
+            $self->add_info_advice(
+                'key'  => 'Kernel_update_available',
+                'text' => $self->_lh->maketext(
+                    'The system kernel is up-to-date at version “[_1]”, thanks to [asis,KernelCare] patches.  However, on reboot, the system will briefly start with version “[_2]” before being patched again by [asis,KernelCare].',
+                    $kernel->{running_version},
+                    $kernel->{unpatched_version},
+                ),
+                'suggestion' => $self->_lh->maketext(
+                    'Install the latest “[_1]” [asis,RPM] package to immediately boot into the latest kernel.',
+                    'kernel',
+                ),
+            );
+        }
+        else {
+            my $VRA = "$kernel->{update_available}{version}-$kernel->{update_available}{release}.$kernel->{update_available}{arch}";
+            $self->add_info_advice(
+                'key'  => 'Kernel_waiting_for_kernelcare_update',
+                'text' => $self->_lh->maketext(
+                    'The system kernel is at version “[_1]”, but an update is available: [_2]',
+                    $kernel->{running_version},
+                    $VRA,
+                ),
+                'suggestion' => _make_unordered_list(
+                    $self->_lh->maketext('You must take one of the following actions to ensure the system is up-to-date:'),
+                    $self->_lh->maketext('Wait a few days for [asis,KernelCare] to publish a kernel patch.'),
+                    _msg_update_and_reboot($self),
+                ),
+            );
+        }
     }
     else {
         $self->add_good_advice(

--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -344,6 +344,25 @@ sub _check_kernelcare_kernel {
             );
         }
     }
+    elsif ( $kernel->{reboot_required} ) {
+        $self->add_info_advice(
+            'key'  => 'Kernel_waiting_for_kernelcare_update_2',
+            'text' => $self->_lh->maketext(
+                'The system kernel is at version “[_1]”, but is set to boot to version “[_2]”.',
+                $kernel->{running_version},
+                $kernel->{boot_version},
+            ),
+            'suggestion' => _make_unordered_list(
+                $self->_lh->maketext('You must take one of the following actions to ensure the system is up-to-date:'),
+                $self->_lh->maketext('Wait a few days for [asis,KernelCare] to publish a kernel patch.'),
+                $self->_lh->maketext(
+                    '[output,url,_1,Reboot the system,_2,_3].',
+                    $self->base_path('scripts/dialog?dialog=reboot'),
+                    'target' => '_blank',
+                ),
+            ),
+        );
+    }
     else {
         $self->add_good_advice(
             'key'  => 'Kernel_kernelcare_is_current',

--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -212,10 +212,7 @@ sub _check_for_kernel_version {
     }
 
     if ( $kernel->{custom_kernel} ) {
-        $self->add_info_advice(
-            'key'  => 'Kernel_can_not_check',
-            'text' => $self->_lh->maketext( 'Custom kernel version cannot be checked to see if it is up to date: [_1]', $kernel->{running_version} )
-        );
+        $self->_check_custom_kernel($kernel);
     }
     elsif ( !$kernel->{has_kernelcare} ) {
         $self->_check_standard_kernel($kernel);
@@ -225,6 +222,34 @@ sub _check_for_kernel_version {
     }
 
     return 1;
+}
+
+sub _check_custom_kernel {
+    my ( $self, $kernel ) = @_;
+
+    if ( $kernel->{reboot_required} ) {
+        $self->add_warn_advice(
+            'key'  => 'Kernel_boot_running_mismatch',
+            'text' => $self->_lh->maketext(
+                'The system kernel is at version “[_1]”, but the system is configured to boot version “[_2]”.',
+                $kernel->{running_version},
+                $kernel->{boot_version},
+            ),
+            'suggestion' => $self->_lh->maketext(
+                '[output,url,_1,Reboot the system,_2,_3]. If the problem persists, check the [asis,GRUB] boot configuration.',
+                $self->base_path('scripts/dialog?dialog=reboot'),
+                'target',
+                '_blank'
+            ),
+        );
+    }
+    else {
+        $self->add_info_advice(
+            'key'  => 'Kernel_can_not_check',
+            'text' => $self->_lh->maketext( 'Custom kernel version cannot be checked to see if it is up to date: [_1]', $kernel->{running_version} )
+        );
+    }
+    return;
 }
 
 sub _check_standard_kernel {

--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -273,7 +273,7 @@ sub _check_standard_kernel {
 sub _check_kernelcare_kernel {
     my ( $self, $kernel ) = @_;
 
-    if ( $kernel->{update_available} && !$kernel->{update_excluded} && $kernel->{patch_available} ) {
+    if ( $kernel->{patch_available} ) {
         $self->add_bad_advice(
             'key'        => 'Kernel_kernelcare_update_available',
             'text'       => $self->_lh->maketext('A [asis,KernelCare] update is available.'),
@@ -283,7 +283,7 @@ sub _check_kernelcare_kernel {
                     'Patch the kernel (run “[_1]” on the command line).',
                     'kcarectl --update',
                 ),
-                _msg_update_and_reboot($self),    # TODO: Check reboot_required before recommending.
+                _msg_update_and_reboot($self),    # TODO: Check update_available and reboot_required before recommending.
             ),
         );
     }

--- a/t/lib/Test/Assessor.pm
+++ b/t/lib/Test/Assessor.pm
@@ -1,0 +1,91 @@
+package Test::Assessor;
+
+# Copyright (c) 2017, cPanel, Inc.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+use Cpanel::Locale ();
+use Cpanel::Security::Advisor ();    # For ADVISE_GOOD, et. al.
+
+sub new {
+    my ( $class, %options ) = @_;
+
+    my $module_name = "Cpanel::Security::Advisor::Assessors::$options{assessor}";
+
+    my $self = bless {
+        locale => Cpanel::Locale->get_handle(),
+    }, $class;
+
+    eval "require $module_name" or die $@;    ##no critic (ProhibitStringyEval) -- require $module_name; doesn't work for some reason.
+    my $assessor = "$module_name"->new($self);
+    $self->{assessor} = $assessor;
+
+    return $self;
+}
+
+sub generate_advice {
+    my ($self) = @_;
+    return $self->{assessor}->generate_advice();
+}
+
+sub add_advice {
+    my ( $self, $advice ) = @_;
+
+    # Some assessor modules call methods directly on instances of this class,
+    # and some use wrapper methods, so try to figure out the module name
+    # regardless of which path we took.
+    my ( $module, $function );
+    foreach my $level ( 1, 3 ) {
+        my $caller = ( caller($level) )[3];
+        if ( $caller =~ /(Cpanel::Security::Advisor::Assessors::.+)::([^:]+)$/ ) {
+            ( $module, $function ) = ( $1, $2 );
+            last;
+        }
+    }
+
+    push @{ $self->{advice} }, {
+        module   => $module,
+        function => $function,
+        advice   => $advice,
+    };
+
+    return;
+}
+
+sub get_advice {
+    my ($self) = @_;
+    return $self->{advice};
+}
+
+sub clear_advice {
+    my ($self) = @_;
+    $self->{advice} = [];
+    return;
+}
+
+1;

--- a/t/pkg-Cpanel-Security-Advisor-Assessors-Kernel.t
+++ b/t/pkg-Cpanel-Security-Advisor-Assessors-Kernel.t
@@ -1,0 +1,517 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+# Copyright (c) 2017, cPanel, Inc.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../pkg";
+
+use Test::More;
+use Test::Deep;
+use Test::MockModule;
+
+use Test::Assessor ();
+
+use Cpanel::Exception ();
+use Cpanel::Version   ();
+
+plan skip_all => 'Requires cPanel & WHM v66 or later' if Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.65' );
+plan tests => 5;
+
+my $envtype = Test::MockModule->new('Cpanel::OSSys::Env');
+$envtype->mock( get_envtype => sub { 'lxc' } );    # Disable KernelCare advertisements.
+
+subtest 'Error parsing boot configuration' => sub {
+    plan tests => 2;
+
+    my $status = Test::MockModule->new('Cpanel::Kernel::Status');
+    $status->mock( kernel_status => sub { die Cpanel::Exception->create('Cannot determine startup kernel version.') } );
+
+    my $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_check_error',
+            text => 'The system cannot check the kernel status: Cannot determine startup kernel version.',
+            type => $Cpanel::Security::Advisor::ADVISE_WARN,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Handle empty return errors' );
+
+    $status->mock( kernel_status => sub { die "Unable to locate grub2-editenv binary. You may need to re-install grub2-tools package.\n" } );
+    $expected->{advice}{text} = "The system cannot check the kernel status: Unable to locate grub2-editenv binary. You may need to re-install grub2-tools package.\n";
+    cmp_assessor( 'Kernel', [$expected], 'Handle string errors' );
+};
+
+subtest 'Unsupported environment' => sub {
+    plan tests => 1;
+
+    my $status = Test::MockModule->new('Cpanel::Kernel::Status');
+    $status->mock( kernel_status => sub { die Cpanel::Exception::create( 'Unsupported', 'Cannot update this system’s kernel.' ) } );
+
+    my $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_unsupported_environment',
+            text => 'The system cannot update the kernel: Cannot update this system’s kernel.',
+            type => $Cpanel::Security::Advisor::ADVISE_INFO,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Notify on unsupported platform' );
+};
+
+subtest 'Custom kernels' => sub {
+    plan tests => 2;
+
+    my %status = (
+        custom_kernel   => 1,
+        running_version => '3.10.0-514.el7.x86_64.grsec',
+        boot_version    => '3.10.0-514.el7.x86_64.grsec',
+        reboot_required => 0,
+    );
+    my $status = Test::MockModule->new('Cpanel::Kernel::Status');
+    $status->mock( kernel_status => sub { \%status } );
+
+    my $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_can_not_check',
+            text => 'Custom kernel version cannot be checked to see if it is up to date: 3.10.0-514.el7.x86_64.grsec',
+            type => $Cpanel::Security::Advisor::ADVISE_INFO,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Boot and running version match' );
+
+    # Mismatch boot & running versions.
+    $status{boot_version}    = '3.10.0-514.6.2.el7.x86_64.grsec';
+    $status{reboot_required} = 1;
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_boot_running_mismatch',
+            text       => 'The system kernel is at version “3.10.0-514.el7.x86_64.grsec”, but the system is configured to boot version “3.10.0-514.6.2.el7.x86_64.grsec”.',
+            suggestion => 'Reboot the system (../scripts/dialog?dialog=reboot). If the problem persists, check the GRUB boot configuration.',
+            type       => $Cpanel::Security::Advisor::ADVISE_WARN,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Boot and running version mismatch' );
+};
+
+subtest 'Standard kernel' => sub {
+    plan tests => 5;
+
+    my %status = (
+        has_kernelcare   => 0,
+        running_version  => '3.10.0-514.el7.x86_64',
+        boot_version     => '3.10.0-514.el7.x86_64',
+        reboot_required  => 0,
+        update_available => undef,
+        running_latest   => 1,
+    );
+    my $status = Test::MockModule->new('Cpanel::Kernel::Status');
+    $status->mock( kernel_status => sub { \%status } );
+
+    my $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_running_is_current',
+            text => 'The system kernel is up-to-date at version “3.10.0-514.el7.x86_64”.',
+            type => $Cpanel::Security::Advisor::ADVISE_GOOD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Up to date system' );
+
+    %status = (
+        has_kernelcare   => 0,
+        running_version  => '3.10.0-514.el7.x86_64',
+        boot_version     => '3.10.0-514.6.2.el7.x86_64',
+        reboot_required  => 1,
+        update_available => undef,
+        running_latest   => 0,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_boot_running_mismatch',
+            text       => 'The system kernel is at version “3.10.0-514.el7.x86_64”, but the system is configured to boot version “3.10.0-514.6.2.el7.x86_64”.',
+            suggestion => 'Reboot the system (../scripts/dialog?dialog=reboot). If the problem persists, check the GRUB boot configuration.',
+            type       => $Cpanel::Security::Advisor::ADVISE_BAD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Boot and running version mismatch' );
+
+    %status = (
+        has_kernelcare   => 0,
+        running_version  => '3.10.0-514.el7.x86_64',
+        boot_version     => '3.10.0-514.el7.x86_64',
+        reboot_required  => 0,
+        update_available => {
+            rpm     => 'kernel-3.10.0-514.10.2.el7.x86_64',
+            name    => 'kernel',
+            version => '3.10.0',
+            release => '514.10.2.el7',
+            arch    => 'x86_64',
+        },
+        running_latest => 0,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_outdated',
+            text       => 'The system kernel is at version “3.10.0-514.el7.x86_64”, but an update is available: 3.10.0-514.10.2.el7.x86_64',
+            suggestion => 'Update the system (run “yum -y update” on the command line), and reboot the system (../scripts/dialog?dialog=reboot).',
+            type       => $Cpanel::Security::Advisor::ADVISE_BAD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Update available' );
+
+    $status{update_excluded} = 1;
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_running_is_current',
+            text => 'The system kernel is up-to-date at version “3.10.0-514.el7.x86_64”.',
+            type => $Cpanel::Security::Advisor::ADVISE_GOOD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Update available, but excluded' );
+
+    %status = (
+        has_kernelcare   => 0,
+        running_version  => '3.10.0-514.el7.x86_64',
+        boot_version     => '3.10.0-514.6.2.el7.x86_64',
+        reboot_required  => 1,
+        update_available => {
+            rpm     => 'kernel-3.10.0-514.10.2.el7.x86_64',
+            name    => 'kernel',
+            version => '3.10.0',
+            release => '514.10.2.el7',
+            arch    => 'x86_64',
+        },
+        running_latest => 0,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_outdated',
+            text       => 'The system kernel is at version “3.10.0-514.el7.x86_64”, but an update is available: 3.10.0-514.10.2.el7.x86_64',
+            suggestion => 'Update the system (run “yum -y update” on the command line), and reboot the system (../scripts/dialog?dialog=reboot).',
+            type       => $Cpanel::Security::Advisor::ADVISE_BAD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Update available & boot and running version mismatch' );
+};
+
+subtest 'KernelCare systems' => sub {
+    plan tests => 12;
+
+    my %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.el7.x86_64',
+        boot_version      => '3.10.0-514.el7.x86_64',
+        reboot_required   => 0,
+        update_available  => undef,
+        patch_available   => 0,
+        running_latest    => 1,
+    );
+    my $status = Test::MockModule->new('Cpanel::Kernel::Status');
+    $status->mock( kernel_status => sub { \%status } );
+
+    my $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_kernelcare_is_current',
+            text => 'The system kernel is up-to-date at version “3.10.0-514.el7.x86_64”.',
+            type => $Cpanel::Security::Advisor::ADVISE_GOOD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Up to date system' );
+
+    %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.el7.x86_64',
+        boot_version      => '3.10.0-514.6.2.el7.x86_64',
+        reboot_required   => 1,
+        update_available  => undef,
+        patch_available   => 0,
+        running_latest    => 0,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_waiting_for_kernelcare_update_2',
+            text       => 'The system kernel is at version “3.10.0-514.el7.x86_64”, but is set to boot to version “3.10.0-514.6.2.el7.x86_64”.',
+            suggestion => 'You must take one of the following actions to ensure the system is up-to-date:<ul><li>Wait a few days for KernelCare to publish a kernel patch.</li><li>Reboot the system (../scripts/dialog?dialog=reboot).</li></ul>',
+            type       => $Cpanel::Security::Advisor::ADVISE_INFO,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Boot and running version mismatch' );
+
+    %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.el7.x86_64',
+        boot_version      => '3.10.0-514.el7.x86_64',
+        reboot_required   => 0,
+        update_available  => {
+            rpm     => 'kernel-3.10.0-514.10.2.el7.x86_64',
+            name    => 'kernel',
+            version => '3.10.0',
+            release => '514.10.2.el7',
+            arch    => 'x86_64',
+        },
+        patch_available => 0,
+        running_latest  => 0,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_waiting_for_kernelcare_update',
+            text       => 'The system kernel is at version “3.10.0-514.el7.x86_64”, but an update is available: 3.10.0-514.10.2.el7.x86_64',
+            suggestion => 'You must take one of the following actions to ensure the system is up-to-date:<ul><li>Wait a few days for KernelCare to publish a kernel patch.</li><li>Update the system (run “yum -y update” on the command line), and reboot the system (../scripts/dialog?dialog=reboot).</li></ul>',
+            type       => $Cpanel::Security::Advisor::ADVISE_INFO,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Update available' );
+
+    $status{update_excluded} = 1;
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_kernelcare_is_current',
+            text => 'The system kernel is up-to-date at version “3.10.0-514.el7.x86_64”.',
+            type => $Cpanel::Security::Advisor::ADVISE_GOOD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Update available, but excluded' );
+
+    %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.el7.x86_64',
+        boot_version      => '3.10.0-514.6.2.el7.x86_64',
+        reboot_required   => 1,
+        update_available  => {
+            rpm     => 'kernel-3.10.0-514.10.2.el7.x86_64',
+            name    => 'kernel',
+            version => '3.10.0',
+            release => '514.10.2.el7',
+            arch    => 'x86_64',
+        },
+        patch_available => 0,
+        running_latest  => 0,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_waiting_for_kernelcare_update',
+            text       => 'The system kernel is at version “3.10.0-514.el7.x86_64”, but an update is available: 3.10.0-514.10.2.el7.x86_64',
+            suggestion => 'You must take one of the following actions to ensure the system is up-to-date:<ul><li>Wait a few days for KernelCare to publish a kernel patch.</li><li>Update the system (run “yum -y update” on the command line), and reboot the system (../scripts/dialog?dialog=reboot).</li></ul>',
+            type       => $Cpanel::Security::Advisor::ADVISE_INFO,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Update available & boot and running version mismatch' );
+
+    # Begin KC patches
+
+    %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.2.2.el7.x86_64',
+        boot_version      => '3.10.0-514.6.2.el7.x86_64',
+        reboot_required   => 0,
+        update_available  => undef,
+        patch_available   => 1,
+        running_latest    => 0,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_kernelcare_update_available',
+            text       => 'A KernelCare update is available.',
+            suggestion => 'You must take one of the following actions to ensure the system is up-to-date:<ul><li>Patch the kernel (run “kcarectl --update” on the command line).</li><li>Update the system (run “yum -y update” on the command line), and reboot the system (../scripts/dialog?dialog=reboot).</li></ul>',
+            type       => $Cpanel::Security::Advisor::ADVISE_BAD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Patch available' );
+
+    $status{update_available} = {
+        rpm     => 'kernel-3.10.0-514.10.2.el7.x86_64',
+        name    => 'kernel',
+        version => '3.10.0',
+        release => '514.10.2.el7',
+        arch    => 'x86_64',
+    };
+
+    # $expected is unchanged
+    cmp_assessor( 'Kernel', [$expected], 'Patch and RPM available' );
+
+    %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.2.2.el7.x86_64',
+        boot_version      => '3.10.0-514.el7.x86_64',
+        reboot_required   => 0,
+        update_available  => undef,
+        patch_available   => 0,
+        running_latest    => 1,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_kernelcare_is_current',
+            text => 'The system kernel is up-to-date at version “3.10.0-514.2.2.el7.x86_64”.',
+            type => $Cpanel::Security::Advisor::ADVISE_GOOD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Patch applied, but RPM not available' );
+
+    %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.2.2.el7.x86_64',
+        boot_version      => '3.10.0-514.2.2.el7.x86_64',
+        reboot_required   => 0,
+        update_available  => undef,
+        patch_available   => 0,
+        running_latest    => 1,
+    );
+
+    # $expected is unchanged
+    cmp_assessor( 'Kernel', [$expected], 'Patch applied & RPM installed; no updates available' );
+
+    %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.2.2.el7.x86_64',
+        boot_version      => '3.10.0-514.6.2.el7.x86_64',
+        reboot_required   => 1,
+        update_available  => undef,
+        patch_available   => 0,
+        running_latest    => 0,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_waiting_for_kernelcare_update_2',
+            text       => 'The system kernel is at version “3.10.0-514.2.2.el7.x86_64”, but is set to boot to version “3.10.0-514.6.2.el7.x86_64”.',
+            suggestion => 'You must take one of the following actions to ensure the system is up-to-date:<ul><li>Wait a few days for KernelCare to publish a kernel patch.</li><li>Reboot the system (../scripts/dialog?dialog=reboot).</li></ul>',
+            type       => $Cpanel::Security::Advisor::ADVISE_INFO,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Waiting for patch, RPM update applied' );
+
+    %status = (
+        has_kernelcare    => 1,
+        unpatched_version => '3.10.0-514.el7.x86_64',
+        running_version   => '3.10.0-514.10.2.el7.x86_64',
+        boot_version      => '3.10.0-514.el7.x86_64',
+        reboot_required   => 0,
+        update_available  => {
+            rpm     => 'kernel-3.10.0-514.10.2.el7.x86_64',
+            name    => 'kernel',
+            version => '3.10.0',
+            release => '514.10.2.el7',
+            arch    => 'x86_64',
+        },
+        patch_available => 0,
+        running_latest  => 1,
+    );
+
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key        => 'Kernel_update_available',
+            text       => 'The system kernel is up-to-date at version “3.10.0-514.10.2.el7.x86_64”, thanks to KernelCare patches.  However, on reboot, the system will briefly start with version “3.10.0-514.el7.x86_64” before being patched again by KernelCare.',
+            suggestion => 'Install the latest “kernel” RPM package to immediately boot into the latest kernel.',
+            type       => $Cpanel::Security::Advisor::ADVISE_INFO,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Patch applied, but RPM not installed' );
+
+    $status{update_excluded} = 1;
+    $expected = {
+        module   => 'Cpanel::Security::Advisor::Assessors::Kernel',
+        function => ignore(),
+        advice   => {
+            key  => 'Kernel_kernelcare_is_current',
+            text => 'The system kernel is up-to-date at version “3.10.0-514.10.2.el7.x86_64”.',
+            type => $Cpanel::Security::Advisor::ADVISE_GOOD,
+        },
+    };
+    cmp_assessor( 'Kernel', [$expected], 'Patched applied, but RPM update excluded' );
+};
+
+sub cmp_assessor {
+    my ( $assessor, $expected, $msg ) = @_;
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    my $object = Test::Assessor->new( assessor => $assessor );
+    $object->generate_advice();
+
+    my $got = $object->get_advice();
+    $object->clear_advice();
+
+    my $ret = cmp_deeply( $got, $expected, $msg );
+    diag explain $got if !$ret;
+
+    return $ret;
+}


### PR DESCRIPTION
This builds on the changes CPANEL-12259 and aims to deduplicate the logic and to generally consume small bits of technical debt.