### PR TITLE
Replace MySQL command to drop anonymous users with one that works.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Mysql.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Mysql.pm
@@ -120,7 +120,7 @@ sub _check_for_anonymous_users {
         $self->add_bad_advice(
             'key'        => 'Mysql_found_anonymous_users',
             'text'       => $self->_lh->maketext("You have some anonymous mysql users"),
-            'suggestion' => $self->_lh->maketext(q{Remove mysql anonymous mysql users: > mysql -e 'drop user ""'})
+            'suggestion' => $self->_lh->maketext(q{Remove mysql anonymous mysql users: > mysql -e "DELETE FROM mysql.user WHERE User=''; FLUSH PRIVILEGES;"})
         );
     }
 


### PR DESCRIPTION
Case CPANEL-16551:

Previously the mysql command offered to drop the anonymous user
would fail if there were multiple anonymous users, mapped to
different hosts.

This command avoid the problematic "drop user" syntax which doesn't
work well with multiple users, as the db engine expands the host
to '%', and then the drop user syntax fails because it does not
handle the wildcard for the host properly in a fully qualified
database user name specification.

The solution is to just delete the users with a where statement,
and then flush the pprivileges to ensure correct security state.
This will also trigger cascade deletes of grants the user had
before it was deleted.