### PR TITLE
Don't offer free symlink patch from KC if on CloudLinux

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -113,8 +113,8 @@ sub _suggest_kernelcare {
         );
     }
 
-    # don't offer Free patch set if Default is detected - SWAT-780
-    elsif ( $kernelcare_state != $Cpanel::KernelCare::KC_DEFAULT_PATCH_SET ) {
+    # don't offer Free patch set if Default is detected - SWAT-780, or if on CloudLinux (KC free tier already baked into CL kernel)
+    elsif ( $kernelcare_state != $Cpanel::KernelCare::KC_DEFAULT_PATCH_SET and Cpanel::KernelCare::system_supports_kernelcare_free() ) {
         my $doclink = $self->_lh->maketext( q{You can protect against this in multiple ways. Please review the following [output,url,_1,documentation,_2,_3] to find a solution that is suited to your needs.}, ($is_ea4) ? 'https://go.cpanel.net/EA4Symlink' : 'https://go.cpanel.net/apachesymlink', 'target', '_blank' );
         $promotion = $self->_lh->maketext(q{This free patch set protects your system from symlink attacks. Add KernelCare's Free Patch Set.});
         $note      = $self->_lh->maketext(q{NOTE: This is not the full KernelCare product and service.});


### PR DESCRIPTION
Case CPANEL-17735: CL kernel already comes baked in with the symlink
protection patch, so even thought CL is supported by KernelCare, we do
not need to offer the free tier at all.

Work done in subtask SWAT-862, parent case SWAT-838.

Requires changes made to upstream 70 via Case CPANEL-17591.