### PR TITLE
Disable addon_securityadvisor.cgi on dnsonly servers

### DIFF
--- a/pkg/cgi/addon_securityadvisor.cgi
+++ b/pkg/cgi/addon_securityadvisor.cgi
@@ -84,7 +84,7 @@ sub run {
 sub _check_acls {
     Whostmgr::ACLS::init_acls();
 
-    if ( !Whostmgr::ACLS::hasroot() ) {
+    if ( !Whostmgr::ACLS::hasroot() || -e q{/var/cpanel/dnsonly} ) {
         _headers('text/html');
         Whostmgr::HTMLInterface::defheader('cPanel Security Advisor');
         print <<'EOM';


### PR DESCRIPTION
Case CPANEL-18480:

Disable addon_securityadvisor.cgi on dnsonly servers.