### PR TITLE
Note that mailman may not work under jailshell

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
@@ -89,7 +89,7 @@ sub _check_for_apache_chroot {
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => $self->_lh->maketext('Apache vhosts are not segmented or chroot()ed.'),
                 'suggestion' => $self->_lh->maketext(
-                    'Enable “Jail Apache” in the “[output,url,_1,Tweak Settings,_4,_5]” area, and change users to jailshell in the “[output,url,_2,Manage Shell Access,_4,_5]” area.  Consider a more robust solution by using “[output,url,_3,CageFS on CloudLinux,_4,_5]”',
+                    'Enable “Jail Apache” in the “[output,url,_1,Tweak Settings,_4,_5]” area, and change users to jailshell in the “[output,url,_2,Manage Shell Access,_4,_5]” area.  Consider a more robust solution by using “[output,url,_3,CageFS on CloudLinux,_4,_5]”.  Note that this may break the ability to access mailman via Apache.',
                     $self->base_path('scripts2/tweaksettings?find=jailapache'),
                     $self->base_path('scripts2/manageshells'),
                     'https://go.cpanel.net/cloudlinux',


### PR DESCRIPTION
Case CPANEL-18127: When using the Jail Apache tweak setting, some
features of Mailman are unavailable due to those paths not being mounted
in jailshell.  For the moment, mark this as a known issue in the
Security Advisor so people can make a reasonable decision whether to
enable this setting.