### PR TITLE
Add SSH Tunnel check to SSH.pm to prevent users with shell access fro…

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/SSH.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/SSH.pm
@@ -88,6 +88,28 @@ sub _check_for_ssh_settings {
 
     }
 
+    # XXX With default C7 sshd_config, X11Forwarding to yes implies everything else will be yes, so only check one item and then advise to disable everything else
+
+    if ( $sshd_config->{'X11Forwarding'} =~ m/yes/i ) {
+        $self->add_bad_advice(
+            'key'        => 'SSH_tunnels_allowed',
+            'text'       => $self->_lh->maketext('SSH Tunnels are allowed.'),
+            'suggestion' => $self->_lh->maketext(
+                'Manually edit /etc/ssh/sshd_config and set "AllowAgentForwarding", "AllowTcpForwarding", and "X11Forwarding" to "no", Then restart SSH in the “[output,url,_1,Restart SSH,_2,_3]” area',
+                $self->base_path('scripts/ressshd'),
+                'target',
+                '_blank'
+            ),
+        );
+    }
+    else {
+        $self->add_good_advice(
+            'key'  => 'SSH_tunnels_allowed',
+            'text' => $self->_lh->maketext('SSH tunnels are disabled.'),
+        );
+
+    }
+
     return 1;
 
 }


### PR DESCRIPTION
…m creating spam tunnels.

In the past, we have seen some instances of malicious users creating local SSH tunnels to send out spam email - They could also use tunnels to commit abusive behavior overall, for example, a user could technically create a ssh tunnel between a few different hacked servers for brute force attacks.

This patch checks sshd_config (Tested against C7 + 11.66) and looks for X11Forwarding being set to yes, which implies default configuration (stock C7 enables all 3 methods of forwarding by default)