### PR TITLE
Add Imunify360 check to Security Advisor.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -1,0 +1,102 @@
+package Cpanel::Security::Advisor::Assessors::Imunify360;
+
+# Copyright (c) 2019, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+use base 'Cpanel::Security::Advisor::Assessors';
+
+use Cpanel::Config::Sources ();
+use Cpanel::Version         ();
+use Whostmgr::Imunify360    ();
+
+use Cpanel::Imports;
+
+our $IMUNIFY360_MINIMUM_CPWHM_VERSION = '11.79';    # we want it usable on both development and release builds for 11.80
+
+sub version {
+    return '1.00';
+}
+
+sub generate_advice {
+    my ($self) = @_;
+
+    eval {
+        if ( Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '>=', $IMUNIFY360_MINIMUM_CPWHM_VERSION ) ) {
+
+            $self->_suggest_imunify360;
+        }
+    };
+    if ( my $exception = $@ ) {
+        print STDERR $exception;    # STDERR gets sent to ULC/logs/error_log.
+        die $exception;
+    }
+
+    return 1;
+}
+
+sub _suggest_imunify360 {
+    my ($self) = @_;
+
+    if ( !Whostmgr::Imunify360::is_imunify360_licensed() ) {
+        my $imunify360_price = Whostmgr::Imunify360::get_imunify360_price();
+        my $store_url        = Cpanel::Config::Sources::get_source('STORE_SERVER_URL');
+        my $url              = "$store_url/view/imunify360/license-options";
+
+        my $purchase_link =
+          $imunify360_price
+          ? locale()->maketext( '[output,url,_1,Get Imunify360,_2,_3] for [_4].', $url, 'target', '_blank', "\$$imunify360_price/month" )
+          : locale()->maketext( '[output,url,_1,Get Imunify360,_2,_3].',          $url, 'target', '_blank' );
+
+        $self->add_warn_advice(
+            key          => 'Imunify360_purchase',
+            text         => locale()->maketext('Use [asis,Imunify360] to protect your server.'),
+            suggestion   => locale()->maketext('[asis,Imunify360] blocks attacks in real-time using a combination of technologies, including Advanced Firewall, Intrusion Detection and Protection System, Malware Detection, [asis,Proactive Defense™], Patch Management, and Reputation Management.') . '<br /><br />' . $purchase_link,
+            block_notify => 1,                                                                                                                                                                                                                                                       # Do not send a notification about this
+        );
+    }
+    elsif ( !Whostmgr::Imunify360::is_imunify360_installed() ) {
+
+        $self->add_warn_advice(
+            key          => 'Imunify360_install',
+            text         => locale()->maketext('You have an [asis,Imunify360] license, but you do not have [asis,Imunify360] installed on your server.'),
+            suggestion   => locale()->maketext('Install [asis,Imunify360].'),
+            block_notify => 1,                                                                                                                                                                                                                                                       # Do not send a notification about this
+        );
+    }
+    else {
+        $self->add_good_advice(
+            key          => 'Imunify360_present',
+            text         => locale()->maketext('Your server is protected by [asis,Imunify360].'),
+            block_notify => 1,                                                                                                                                                                                                                                                       # Do not send a notification about this
+        );
+    }
+
+    return 1;
+}
+
+1;

--- a/pkg/templates/main.tmpl
+++ b/pkg/templates/main.tmpl
@@ -153,11 +153,12 @@ Scanner.prototype.parse_comet_message = function(data) {
     else if (data.type == "mod_advice") {
         var advise_notice_type = data.advice.type == 8 ? "error" : data.advice.type == 4 ? "warn" : data.advice.type == 2 ? "info" : "success";
 
+        var messageId = YAHOO.lang.escapeHTML(data.advice.key);
         new Page_Notice({
                         level: advise_notice_type,
                         type: data.advice.type,
                         container: DOM.get('securityadvice_' + advise_notice_type),
-                        content: data.advice.text + (data.advice.suggestion ? ("<blockquote>" + data.advice.suggestion + "</blockquote>") : "")
+                        content: "<div id=\"" + messageId + "\">" + data.advice.text + (data.advice.suggestion ? ("<blockquote>" + data.advice.suggestion + "</blockquote>") : "") + "</div>"
                 }).show();
     }
     else {

--- a/t/pkg-Cpanel-Security-Advisor-Assessors-Imunify360.t
+++ b/t/pkg-Cpanel-Security-Advisor-Assessors-Imunify360.t
@@ -1,0 +1,103 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+# Copyright (c) 2018, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL  BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../pkg";
+
+use Cpanel::Version ();
+use Test::Assessor  ();
+use Test::More;
+use Test::MockModule;
+
+use Cpanel::Security::Advisor::Assessors::Imunify360 ();
+
+plan skip_all => 'Requires cPanel & WHM v80 or later' if Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.79' );
+
+plan tests => 4;
+
+my $mocked_version_module    = Test::MockModule->new('Cpanel::Version');
+my $mocked_imunify360_module = Test::MockModule->new('Whostmgr::Imunify360');
+
+subtest 'Requires cPanel v80 or later' => sub {
+    plan tests => 1;
+
+    $mocked_version_module->redefine( getversionnumber => sub { '11.70' } );
+
+    my $advice = get_advice();
+
+    is_deeply( $advice, [], "Should not get advice for versions lower than 80" ) or diag explain $advice;
+};
+
+$mocked_version_module->redefine( getversionnumber => sub { '11.80' } );
+
+subtest 'Advice to buy an Imunify360 license' => sub {
+    plan tests => 1;
+
+    $mocked_imunify360_module->redefine( is_imunify360_licensed => sub { 0 } );
+
+    my $advice      = get_advice();
+    my $advice_text = $advice->[0]->{'advice'}->{'text'};
+
+    is( $advice_text, "Use Imunify360 to protect your server.", "It should advice buying an Imunify360 license" );
+};
+
+subtest 'Has a license but Imunify360 is not installed' => sub {
+    plan tests => 1;
+
+    $mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 1 } );
+    $mocked_imunify360_module->redefine( is_imunify360_installed => sub { 0 } );
+
+    my $advice      = get_advice();
+    my $advice_text = $advice->[0]->{'advice'}->{'text'};
+
+    is( $advice_text, "You have an Imunify360 license, but you do not have Imunify360 installed on your server.", "It should advice installing Imunify360" );
+};
+
+subtest 'Imunify360 is installed' => sub {
+    plan tests => 1;
+
+    $mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 1 } );
+    $mocked_imunify360_module->redefine( is_imunify360_installed => sub { 1 } );
+
+    my $advice      = get_advice();
+    my $advice_text = $advice->[0]->{'advice'}->{'text'};
+
+    is( $advice_text, "Your server is protected by Imunify360.", "It should say that the server is protected" );
+};
+
+sub get_advice {
+    my $object = Test::Assessor->new( assessor => 'Imunify360' );
+    $object->generate_advice();
+    my $advice = $object->get_advice();
+    $object->clear_advice();
+
+    return $advice;
+}


### PR DESCRIPTION
Case LC-10352: This commit is a squash of the Imunify360 check
changes from LC story 10290.

The check covers the following items:

- Does this server have an Imunify360 license?

- Is Imunify360 actually installed on this server?

If the answer to either of the above is "no," then a suggestion
is displayed. We are only providing a link to the cPanel store
currently and have not integrated the purchase process into WHM. A
future story is expected to cover the tighter integration of the
purchase process, similar to what's done with KernelCare.

Requirements:

- The new check will only work on v80+, and we only intend to update
the submodule commit for v80 and greater. If the submodule commit
does get bumped up on an older version, the Security Advisor will
still function, but the new check will not be included.