### PR TITLE
Only mention KernelCare's "Extra" patchset on supported systems.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -205,7 +205,12 @@ sub _suggest_kernelcare {
         }
 
         $suggestion = ($suggestion) ? '<p/><p/>' . $suggestion : '';
-        $promotion = $self->_lh->maketext('KernelCare provides an easy and effortless way to ensure that your operating system uses the most up-to-date kernel without the need to reboot your server. After you purchase and install KernelCare, you can obtain and install the KernelCare "Extra" Patchset, which includes symlink protection.');
+        $promotion = $self->_lh->maketext('KernelCare provides an easy and effortless way to ensure that your operating system uses the most up-to-date kernel without the need to reboot your server.');
+
+        # Verifies the user is on CentOS 6 or 7, and is not running CloudLinux.
+        if ( Cpanel::KernelCare::system_supports_kernelcare_free() ) {
+            $promotion .= $self->_lh->maketext(' After you purchase and install KernelCare, you can obtain and install the KernelCare "Extra" Patchset, which includes symlink protection.');
+        }
 
         $self->add_warn_advice(
             'key'          => 'Kernel_kernelcare_purchase',


### PR DESCRIPTION
Case CPANEL-25984: We were suggesting that the "Extra" patchset would be
available for download after purchasing KernelCare, regardless of
whether or not the system is compatiable. To avoid this, I've added
logic to only display this message on CentOS 6/7 systems.

Changelog: Only mention KernelCare "Extra" patchset on supported
 systems.