### PR TITLE
Fix a couple of warnings in securityadvisor (SSH & Kernel modules)

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -97,7 +97,7 @@ sub _suggest_kernelcare {
     return if !Cpanel::KernelCare::system_supports_kernelcare() || Cpanel::Security::Advisor::Assessors::Symlinks->new->has_cpanel_hardened_kernel();
 
     # Abort if kernelcare is already licensend
-    return if try { Cpanel::KernelCare::Availability::system_license_from_cpanel(); };
+    return if eval { Cpanel::KernelCare::Availability::system_license_from_cpanel(); };
 
     my $kernelcare_state = Cpanel::KernelCare::get_kernelcare_state();
 

--- a/pkg/Cpanel/Security/Advisor/Assessors/SSH.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/SSH.pm
@@ -46,8 +46,8 @@ sub generate_advice {
 sub _check_for_ssh_settings {
     my ($self) = @_;
 
-    my $sshd_config = Whostmgr::Services::SSH::Config::get_config();
-
+    my $scfg = Whostmgr::Services::SSH::Config->new();
+    my $sshd_config = $scfg->get_config();
     if ( $sshd_config->{'PasswordAuthentication'} =~ m/yes/i || $sshd_config->{'ChallengeResponseAuthentication'} =~ m/yes/i ) {
         $self->add_bad_advice(
             'key'        => 'SSH_password_authentication_enabled',


### PR DESCRIPTION
One having to do with doing try {} when eval would be better

Another about calling a dynamic method like a static method