### PR TITLE
Go to front of Imunify360 instead of deep linking into UI.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -209,7 +209,7 @@ sub _suggest_imunify360 {
     else {
         my $imunify_whm_link = locale()->maketext(
             '[output,url,_1,Open Imunify360,_2,_3].',
-            $self->base_path('/cgi/imunify/handlers/index.cgi#/admin/dashboard/incidents'),
+            $self->base_path('/cgi/imunify/handlers/index.cgi'),
             'target' => '_parent'
         );
 


### PR DESCRIPTION
In the case where there is a problem with the Imunify360 license,
a deep link into the UI will produce a 404 message rather than
explaining what's actually wrong. This type of license issue should
hopefully never happen outside of a testing environment like ours,
but if it does, the user will get a much more meaningful message
by navigating to the front.

Team-Task: LC-10635
Original-Team-Task: LC_10618
Team-Story: LC_10506