### PR TITLE
v80 and v82 compatibility for Imunify360 assessor in Security Advisor

### DIFF
--- a/t/pkg-Cpanel-Security-Advisor-Assessors-Imunify360.t
+++ b/t/pkg-Cpanel-Security-Advisor-Assessors-Imunify360.t
@@ -36,7 +36,7 @@ use Cpanel::Version ();
 use Test::Assessor  ();
 use Test::Deep;
 use Test::More;
-use Test::NoWarnings;
+use Test::NoWarnings ();
 use Test::MockModule;
 use HTTP::Response;
 
@@ -44,41 +44,89 @@ use Cpanel::Security::Advisor::Assessors::Imunify360 ();
 
 local $ENV{"REQUEST_URI"} = "";
 
-$ENV{'SERVER_PORT'}       = 2087;
-$ENV{'HTTP_HOST'}         = 'example.com';
-$ENV{'cp_security_token'} = '/cpsessXXXXXXX';
-
 plan skip_all => 'Requires cPanel & WHM v80 or later' if Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.79' );
 
-plan tests => 8 + 1;
+plan tests => 7 + 1;
 
-my $mocked_version_module = Test::MockModule->new('Cpanel::Version');
-my $imunify               = Test::MockModule->new('Whostmgr::Imunify360');
+Test::NoWarnings->import();    # defer import until this line for skip_all compatibility
 
-subtest 'When Imunify360 is disabled' => sub {
+my $mocked_version_module    = Test::MockModule->new('Cpanel::Version');
+my $mocked_imunify360_module = Test::MockModule->new('Whostmgr::Imunify360');
+my $mocked_HTTP              = Test::MockModule->new('Cpanel::HTTP::Client');
+my $mocked_cpstore           = Test::MockModule->new('Cpanel::cPStore');
+
+$mocked_cpstore->redefine(
+    get => sub {
+        [
+            { item_id => '373', short_name => 'Imunify360' },    # incomplete but sufficient for the tests
+        ]
+    },
+);
+
+my $response_imunify_disabled = Cpanel::HTTP::Client::Response->new(
+    {
+        success => 1,
+        status  => 200,
+        content => '
+            {
+                "disabled": 1,
+                "url": "",
+                "email": ""
+            }',
+    }
+);
+$response_imunify_disabled->header( 'Content-Type', 'application/json' );
+
+my $response_imunify_enabled = Cpanel::HTTP::Client::Response->new(
+    {
+        success => 1,
+        status  => 200,
+        content => '
+            {
+                "disabled": 0,
+                "url": "",
+                "email": ""
+            }',
+    }
+);
+$response_imunify_enabled->header( 'Content-Type', 'application/json' );
+
+subtest 'When not running v80 or later' => sub {
+    plan tests => 1;
+
+    $mocked_version_module->redefine( getversionnumber => sub { '11.70' } );
+
+    my $advice = get_advice();
+
+    is_deeply( $advice, [], "Should not get advice for versions lower than 80" ) or diag explain $advice;
+};
+
+subtest 'When Imunify360 is disabled in Manage2' => sub {
     plan tests => 1;
 
     $mocked_version_module->redefine( getversionnumber => sub { '11.80' } );
-    $imunify->redefine( should_offer => sub { 0 } );
+    $mocked_HTTP->redefine( 'get' => sub { $response_imunify_disabled } );
     my $advice = get_advice();
 
     is_deeply( $advice, [], "Should not return the Imunify360 advice" ) or diag explain $advice;
 };
 
-subtest 'When Imunify360 is enabled' => sub {
+subtest 'When Imunify360 is enabled in Manage2' => sub {
     plan tests => 1;
 
-    $imunify->redefine( should_offer => sub { 1 } );
+    $mocked_HTTP->redefine( 'get' => sub { $response_imunify_enabled } );
     my $advice = get_advice()->[0];
 
     ok( exists $advice->{'advice'}, "Should return the Imunify360 advice" );
 };
 
+$mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 0 } );
+$mocked_imunify360_module->redefine( is_imunify360_installed => sub { 0 } );
+
 subtest 'When Imunify360 is not installed or licensed' => sub {
     plan tests => 1;
 
-    $imunify->redefine( is_product_licensed  => sub { 0 } );
-    $imunify->redefine( is_product_installed => sub { 0 } );
+    $mocked_imunify360_module->redefine( is_imunify360_licensed => sub { 0 } );
 
     my $advice   = get_advice();
     my $expected = {
@@ -97,8 +145,8 @@ subtest 'When Imunify360 is not installed or licensed' => sub {
 subtest 'When has a license but Imunify360 is not installed' => sub {
     plan tests => 1;
 
-    $imunify->redefine( is_product_licensed  => sub { 1 } );
-    $imunify->redefine( is_product_installed => sub { 0 } );
+    $mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 1 } );
+    $mocked_imunify360_module->redefine( is_imunify360_installed => sub { 0 } );
 
     my $advice   = get_advice();
     my $expected = {
@@ -117,8 +165,8 @@ subtest 'When has a license but Imunify360 is not installed' => sub {
 subtest 'When Imunify360 is installed but not licensed' => sub {
     plan tests => 1;
 
-    $imunify->redefine( is_product_licensed  => sub { 0 } );
-    $imunify->redefine( is_product_installed => sub { 1 } );
+    $mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 0 } );
+    $mocked_imunify360_module->redefine( is_imunify360_installed => sub { 1 } );
 
     my $advice   = get_advice();
     my $expected = {
@@ -137,8 +185,8 @@ subtest 'When Imunify360 is installed but not licensed' => sub {
 subtest 'When Imunify360 is installed and licensed' => sub {
     plan tests => 1;
 
-    $imunify->redefine( is_product_licensed  => sub { 1 } );
-    $imunify->redefine( is_product_installed => sub { 1 } );
+    $mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 1 } );
+    $mocked_imunify360_module->redefine( is_imunify360_installed => sub { 1 } );
 
     my $advice   = get_advice();
     my $expected = {
@@ -152,30 +200,6 @@ subtest 'When Imunify360 is installed and licensed' => sub {
     };
 
     cmp_deeply( $advice->[0], superhashof($expected), "It should say that the server is protected" ) or diag explain $advice;
-};
-
-subtest 'When the custom URL is present' => sub {
-    plan tests => 1;
-
-    $imunify->redefine( get_custom_url       => sub { 'https://example.com' } );
-    $imunify->redefine( is_product_licensed  => sub { 0 } );
-    $imunify->redefine( is_product_installed => sub { 0 } );
-
-    my $advice = get_advice();
-
-    like( $advice->[0]->{advice}->{suggestion}, qr{https://example.com}, "It should change the link href" );
-};
-
-subtest 'When the custom URL is NOT present' => sub {
-    plan tests => 1;
-
-    $imunify->redefine( get_custom_url       => sub { '' } );
-    $imunify->redefine( is_product_licensed  => sub { 0 } );
-    $imunify->redefine( is_product_installed => sub { 0 } );
-
-    my $advice = get_advice();
-
-    like( $advice->[0]->{advice}->{suggestion}, qr{scripts12/purchase_imunify360_init}, "It should link to the init script" );
 };
 
 sub get_advice {


### PR DESCRIPTION
Case CPANEL-27631: As part of our v82 work, the Imunify360 assessor
was refactored in a way that it began using a couple of the new
v82-only capabilities of Whostmgr::Store.  This was OK at first
because v80 was not on the latest SA commit from master, but once
it was updated, it began failing.

The fix here is just to revert the changes to the Imunify360 assessor.
It would be nice to have this on the new style, but it's not actually
necessary. Since it needs to be compatible with v80, we don't have
that option.

Changelog: Fix compatibility issue with Security Advisor assessor.