### PR TITLE
Restore Imunify360 custom URL capability for v82.

### DIFF
--- a/t/pkg-Cpanel-Security-Advisor-Assessors-Imunify360.t
+++ b/t/pkg-Cpanel-Security-Advisor-Assessors-Imunify360.t
@@ -46,14 +46,18 @@ local $ENV{"REQUEST_URI"} = "";
 
 plan skip_all => 'Requires cPanel & WHM v80 or later' if Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.79' );
 
-plan tests => 7 + 1;
-
 Test::NoWarnings->import();    # defer import until this line for skip_all compatibility
 
-my $mocked_version_module    = Test::MockModule->new('Cpanel::Version');
-my $mocked_imunify360_module = Test::MockModule->new('Whostmgr::Imunify360');
-my $mocked_HTTP              = Test::MockModule->new('Cpanel::HTTP::Client');
-my $mocked_cpstore           = Test::MockModule->new('Cpanel::cPStore');
+my $mocked_version_module = Test::MockModule->new('Cpanel::Version');
+my $imunify               = Test::MockModule->new('Whostmgr::Imunify360');
+my $mocked_HTTP           = Test::MockModule->new('Cpanel::HTTP::Client');
+$mocked_HTTP->redefine(
+    get => sub {
+        my @args = @_;
+        die explain [ 'Unmocked HTTP request:', \@args ];
+    }
+);
+my $mocked_cpstore = Test::MockModule->new('Cpanel::cPStore');
 
 $mocked_cpstore->redefine(
     get => sub {
@@ -91,42 +95,37 @@ my $response_imunify_enabled = Cpanel::HTTP::Client::Response->new(
 );
 $response_imunify_enabled->header( 'Content-Type', 'application/json' );
 
-subtest 'When not running v80 or later' => sub {
-    plan tests => 1;
+plan tests => 8 + 1;
 
-    $mocked_version_module->redefine( getversionnumber => sub { '11.70' } );
-
-    my $advice = get_advice();
-
-    is_deeply( $advice, [], "Should not get advice for versions lower than 80" ) or diag explain $advice;
-};
-
-subtest 'When Imunify360 is disabled in Manage2' => sub {
+subtest 'When Imunify360 is disabled' => sub {
     plan tests => 1;
 
     $mocked_version_module->redefine( getversionnumber => sub { '11.80' } );
-    $mocked_HTTP->redefine( 'get' => sub { $response_imunify_disabled } );
+    $mocked_HTTP->redefine( get => $response_imunify_disabled );
     my $advice = get_advice();
 
     is_deeply( $advice, [], "Should not return the Imunify360 advice" ) or diag explain $advice;
 };
 
-subtest 'When Imunify360 is enabled in Manage2' => sub {
+subtest 'When Imunify360 is enabled' => sub {
     plan tests => 1;
 
-    $mocked_HTTP->redefine( 'get' => sub { $response_imunify_enabled } );
-    my $advice = get_advice()->[0];
+    $mocked_version_module->redefine( getversionnumber => sub { '11.80' } );
+    $mocked_HTTP->redefine( get => $response_imunify_enabled );
+    my $advice = get_advice();
 
-    ok( exists $advice->{'advice'}, "Should return the Imunify360 advice" );
+    cmp_deeply( $advice, [ superhashof( { advice => ignore() } ) ], "Should return the Imunify360 advice" )
+      or diag explain $advice;
 };
 
-$mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 0 } );
-$mocked_imunify360_module->redefine( is_imunify360_installed => sub { 0 } );
+$imunify->redefine( is_imunify360_licensed  => sub { 0 } );
+$imunify->redefine( is_imunify360_installed => sub { 0 } );
 
 subtest 'When Imunify360 is not installed or licensed' => sub {
     plan tests => 1;
 
-    $mocked_imunify360_module->redefine( is_imunify360_licensed => sub { 0 } );
+    $imunify->redefine( is_imunify360_licensed  => sub { 0 } );
+    $imunify->redefine( is_imunify360_installed => sub { 0 } );
 
     my $advice   = get_advice();
     my $expected = {
@@ -145,8 +144,8 @@ subtest 'When Imunify360 is not installed or licensed' => sub {
 subtest 'When has a license but Imunify360 is not installed' => sub {
     plan tests => 1;
 
-    $mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 1 } );
-    $mocked_imunify360_module->redefine( is_imunify360_installed => sub { 0 } );
+    $imunify->redefine( is_imunify360_licensed  => sub { 1 } );
+    $imunify->redefine( is_imunify360_installed => sub { 0 } );
 
     my $advice   = get_advice();
     my $expected = {
@@ -165,8 +164,8 @@ subtest 'When has a license but Imunify360 is not installed' => sub {
 subtest 'When Imunify360 is installed but not licensed' => sub {
     plan tests => 1;
 
-    $mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 0 } );
-    $mocked_imunify360_module->redefine( is_imunify360_installed => sub { 1 } );
+    $imunify->redefine( is_imunify360_licensed  => sub { 0 } );
+    $imunify->redefine( is_imunify360_installed => sub { 1 } );
 
     my $advice   = get_advice();
     my $expected = {
@@ -185,8 +184,8 @@ subtest 'When Imunify360 is installed but not licensed' => sub {
 subtest 'When Imunify360 is installed and licensed' => sub {
     plan tests => 1;
 
-    $mocked_imunify360_module->redefine( is_imunify360_licensed  => sub { 1 } );
-    $mocked_imunify360_module->redefine( is_imunify360_installed => sub { 1 } );
+    $imunify->redefine( is_imunify360_licensed  => sub { 1 } );
+    $imunify->redefine( is_imunify360_installed => sub { 1 } );
 
     my $advice   = get_advice();
     my $expected = {
@@ -200,6 +199,42 @@ subtest 'When Imunify360 is installed and licensed' => sub {
     };
 
     cmp_deeply( $advice->[0], superhashof($expected), "It should say that the server is protected" ) or diag explain $advice;
+};
+
+subtest 'When the custom URL is present' => sub {
+    plan tests => 1;
+  SKIP: {
+        if ( Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.81' ) ) {
+            skip 'Only on 82+', 1;
+        }
+
+        $imunify->redefine( get_custom_url          => sub { 'https://example.com' } );
+        $imunify->redefine( is_imunify360_licensed  => sub { 0 } );
+        $imunify->redefine( is_imunify360_installed => sub { 0 } );
+
+        my $advice = get_advice();
+
+        like( $advice->[0]->{advice}->{suggestion}, qr{https://example.com}, "It should change the link href" )
+          or diag explain $advice;
+    }
+};
+
+subtest 'When the custom URL is NOT present' => sub {
+    plan tests => 1;
+
+  SKIP: {
+        if ( Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.81' ) ) {
+            skip 'Only on 82+', 1;
+        }
+        $imunify->redefine( get_custom_url          => sub { '' } );
+        $imunify->redefine( is_imunify360_licensed  => sub { 0 } );
+        $imunify->redefine( is_imunify360_installed => sub { 0 } );
+
+        my $advice = get_advice();
+
+        like( $advice->[0]->{advice}->{suggestion}, qr{scripts12/purchase_imunify360_init}, "It should link to the init script" )
+          or diag explain $advice;
+    }
 };
 
 sub get_advice {


### PR DESCRIPTION
Case CPANEL-27727: As part of the fix for CPANEL case 27631, some of our v82
work was reverted. This commit is a resubmission of the custom URL capability
for v82 in a way that is still compatible with versions prior to 82.

Team-Story: LC_10732
Original-Task: LC_10737
Team-Merge-Task: LC-10743