### PR TITLE
Update links to use the new Whostmgr13 script.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -129,6 +129,13 @@ sub _process_template {
     die "Template processing failed: $output";
 }
 
+sub _get_script_number() {
+    my $current_version = Cpanel::Version::getversionnumber();
+    my $is_v84_or_older = Cpanel::Version::compare( $current_version, '>=', '11.83' );
+
+    return $is_v84_or_older ? 'scripts13' : 'scripts12';
+}
+
 sub create_purchase_link {
     my ($self) = @_;
 
@@ -141,7 +148,7 @@ sub create_purchase_link {
         $custom_url = $imunify360->get_custom_url();
     }
 
-    my $cp_url     = $self->base_path('scripts12/purchase_imunify360_init');
+    my $cp_url = $self->base_path( _get_script_number() . '/purchase_imunify360_init' );
 
     if ($custom_url) {
         return locale()->maketext( '[output,url,_1,Get Imunify360,_2,_3].', $custom_url, 'target', '_blank', );
@@ -201,7 +208,7 @@ sub _suggest_imunify360 {
         my $output = _process_template(
             \_get_install_template(),
             {
-                'path'               => $self->base_path('scripts12/install_imunify360'),
+                'path'               => $self->base_path(  _get_script_number . '/install_imunify360'),
                 'include_kernelcare' => $is_kernelcare_needed,
             }
         );

--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -90,6 +90,13 @@ sub _has_kc_default_patch_set {
     return $state == $Cpanel::KernelCare::KC_DEFAULT_PATCH_SET || $state == $Cpanel::KernelCare::KC_EXTRA_PATCH_SET;
 }
 
+sub _get_script_number() {
+    my $current_version = Cpanel::Version::getversionnumber();
+    my $is_v84_or_older = Cpanel::Version::compare( $current_version, '>=', '11.83' );
+
+    return $is_v84_or_older ? 'scripts13' : 'scripts12';
+}
+
 sub _suggest_kernelcare {
     my ($self) = @_;
 
@@ -126,7 +133,7 @@ sub _suggest_kernelcare {
         $note      = $self->_lh->maketext(q{NOTE: This is not the full KernelCare product and service.});
         my $link = $self->_lh->maketext(
             '[output,url,_1,Add KernelCare\'s Free Symlink Protection,_2,_3].',
-            $self->base_path('scripts12/add_kernelcare_free_symlink_protection'),
+            $self->base_path(_get_script_number() . '/add_kernelcare_free_symlink_protection'),
             'target' => '_parent',
         );
         $self->add_bad_advice(
@@ -173,7 +180,7 @@ sub _suggest_kernelcare {
             'text'       => $self->_lh->maketext('Valid KernelCare License Found, but KernelCare is Not Installed.'),
             'suggestion' => $promotion . ' ' . $self->_lh->maketext(
                 '[output,url,_1,Click to install,_2,_3].',
-                $self->base_path('scripts12/purchase_kernelcare_completion?order_status=success'),
+                $self->base_path(_get_script_number() . '/purchase_kernelcare_completion?order_status=success'),
                 'target' => '_parent',
             ),
         );
@@ -201,7 +208,7 @@ sub _suggest_kernelcare {
             my $price = _get_kernelcare_monthly_price();
             $suggestion = $self->_lh->maketext(
                 '[output,url,_1,Get KernelCare,_2,_3][_4].',
-                $self->base_path('scripts12/purchase_kernelcare_init'),
+                $self->base_path(_get_script_number() . '/purchase_kernelcare_init'),
                 'target' => '_parent',
                 ($price) ? qq{ for \$$price/month} : q{},
             );
@@ -460,7 +467,7 @@ sub _suggest_kernelcare_on_a_cpanel_whm_system_at_v64 {
                 'text'       => $self->_lh->maketext('Valid KernelCare License Found, but KernelCare is Not Installed.'),
                 'suggestion' => $promotion . ' ' . $self->_lh->maketext(
                     '[output,url,_1,Click to install,_2,_3].',
-                    $self->base_path('scripts12/purchase_kernelcare_completion?order_status=success'),
+                    $self->base_path(_get_script_number() . '/purchase_kernelcare_completion?order_status=success'),
                     'target' => '_parent',
                 ),
             );
@@ -484,7 +491,7 @@ sub _suggest_kernelcare_on_a_cpanel_whm_system_at_v64 {
             else {
                 $suggestion = $self->_lh->maketext(
                     '[output,url,_1,Upgrade to KernelCare,_2,_3].',
-                    $self->base_path('scripts12/purchase_kernelcare_init'),
+                    $self->base_path(_get_script_number() . '/purchase_kernelcare_init'),
                     'target' => '_parent',
                 );
             }


### PR DESCRIPTION
Case CPANEL-29071: RTD-112 is introducing a new Whostmgr13 for banners
specific. This fix will update the proper URL (script 12 or 13)
depending on the new script availability.

This patch needs to merge in sync with Whostmgr13 changes from
CPANEL-29070.

Team Case: RTD_1
Merge Case: RTD-152

Changelog: