### PR TITLE
CPANEL-31064

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
@@ -220,10 +220,10 @@ sub _centos_symlink_protection {
     my $jailedapache         = $security_advisor_obj->{'cpconf'}->{'jailapache'};
     my $sysinfo              = Cpanel::GenSysInfo::run();
 
-    my $is_ea4 = ( defined &Cpanel::Config::Httpd::is_ea4 && Cpanel::Config::Httpd::is_ea4() ) ? 1 : 0;
-    my $bluehost_ea3 = ($is_ea4) ? 0 : grep { /SPT_DOCROOT/ } $httpd_binary;
-    my $local_settings = ($is_ea4) ? Cpanel::DataStore::fetch_ref('/var/cpanel/conf/apache/local') : undef;
-    my $bluehost_ea4 = ($is_ea4) ? ( exists $local_settings->{main}->{symlink_protect} && $local_settings->{main}->{symlink_protect}->{item}->{symlink_protect} eq 'On' ) : 0;
+    my $is_ea4         = ( defined &Cpanel::Config::Httpd::is_ea4 && Cpanel::Config::Httpd::is_ea4() ) ? 1                                                                                                                                      : 0;
+    my $bluehost_ea3   = ($is_ea4)                                                                     ? 0                                                                                                                                      : grep { /SPT_DOCROOT/ } $httpd_binary;
+    my $local_settings = ($is_ea4)                                                                     ? Cpanel::DataStore::fetch_ref('/var/cpanel/conf/apache/local')                                                                          : undef;
+    my $bluehost_ea4   = ($is_ea4)                                                                     ? ( exists $local_settings->{main}->{symlink_protect} && $local_settings->{main}->{symlink_protect}->{item}->{symlink_protect} eq 'On' ) : 0;
 
     my $kernelcare_state = Cpanel::KernelCare::get_kernelcare_state();
 

--- a/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
@@ -94,7 +94,8 @@ sub _check_for_apache_chroot {
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text'       => $self->_lh->maketext('Apache vhosts are not segmented or chroot()ed.'),
                 'suggestion' => $self->_lh->maketext(
-                    'Enable “Jail Apache” in the “[output,url,_1,Tweak Settings,_4,_5]” area, and change users to jailshell in the “[output,url,_2,Manage Shell Access,_4,_5]” area.  Consider a more robust solution by using “[output,url,_3,CageFS on CloudLinux,_4,_5]”.  Note that this may break the ability to access mailman via Apache.',
+                    'Enable “mod_ruid2” in the “[output,url,_1,EasyApache 4,_5,_6]” area, enable “Jail Apache” in the “[output,url,_2,Tweak Settings,_5,_6]” area, and change users to jailshell in the “[output,url,_3,Manage Shell Access,_5,_6]” area.  Consider a more robust solution by using “[output,url,_4,CageFS on CloudLinux,_5,_6]”.  Note that this may break the ability to access mailman via Apache.',
+                    $self->base_path('scripts7/EasyApache4'),
                     $self->base_path('scripts2/tweaksettings?find=jailapache'),
                     $self->base_path('scripts2/manageshells'),
                     'https://go.cpanel.net/cloudlinux',


### PR DESCRIPTION
Update apache chroot advice to mention ruid2

Case CPANEL-31064: Clarify that mod_ruid2 is needed to implement the
Apache vhost chroot advice.
