### PR TITLE
Update the security advisor with ImunifyAV

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/ClamAV.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/ClamAV.pm
@@ -30,14 +30,20 @@ use strict;
 use warnings;
 use Cpanel::FindBin         ();
 use Cpanel::SafeRun::Errors ();
+use Cpanel::Version         ();
 
 use base 'Cpanel::Security::Advisor::Assessors';
 
 sub generate_advice {
     my ($self) = @_;
 
-    return 0 if $self->_check_clamav();
+    my $cpanel_version = Cpanel::Version::getversionnumber();
 
+    # Only show the clamav advice if running version 86 and lower.
+    # Otherwise we will recommend ImunifyAV in the Imunify360 module.
+    if ( Cpanel::Version::compare( $cpanel_version, '<=', '11.86' ) ) {
+        return 0 if $self->_check_clamav();
+    }
     return 1;
 }
 


### PR DESCRIPTION
Case BWG-1333

This commit adds the ability to install ImunifyAV and purchase
ImunifyAV+ from the security advisor. It also removes the ClamAV check
from cPanel versions 88 and later and recommends ClamAV be uninstalled
if both ClamAV and ImunifyAV are installed.

Changelog: Update the Security Advisor with ImunifyAV and ImunifyAV+