### PR TITLE
Do not show ImunifyAV and AV+ advice when Imunify360 exists.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -76,7 +76,7 @@ sub generate_advice {
 
         # These checks will only run on v88 and highger.
         if ( Cpanel::Version::compare( $cpanel_version, '>=', $IMUNIFYAV_MINIMUM_CPWHM_VERSION )
-            && ( !$self->{i360}{installed} || !$self->{i360}{licensed} ) ) {
+            && ( !$self->{i360}{installed} && !$self->{i360}{licensed} ) ) {
 
             if ( _can_load_module('Whostmgr::Store::Product::ImunifyAV') ) {
                 my $iav_store = Whostmgr::Store::Product::ImunifyAV->new( redirect_path => 'cgi/securityadvisor/index.cgi' );


### PR DESCRIPTION
Case BWG-1514

It was possible to see the ImunifyAV+ advice when Imunify360 was
installed but not licensed. You will now only see the ImunifyAV+ advice
when Imunify360 is both not installed and not licensed.

Changelog: