### PR TITLE
Fix CSF false-positive installation check

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Brute.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Brute.pm
@@ -57,7 +57,7 @@ sub _check_for_brute_force_protection {
         );
 
     }
-    elsif ( -e "/etc/csf" ) {
+    elsif ( -x "/usr/sbin/csf" ) {
         if ( -e "/etc/csf/csf.disable" ) {
             if ( -e "/usr/local/cpanel/whostmgr/docroot/cgi/configserver/csf" ) {
                 $security_advisor_obj->add_advice(


### PR DESCRIPTION
Case CPANEL-31849: Use executability of /usr/sbin/csf instead of
existence of /etc/csf to determine if CSF is installed. Fixes a
false-positive result caused by other software dropping a configuration
file into /etc/csf while it isn't installed.

Changelog: Fix Security Advisor mistakenly detecting that CSF is
 installed in some cases.