### PR TITLE
Add links to a landing page and info page when advice is good.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -113,6 +113,11 @@ sub generate_advice {
     return 1;
 }
 
+sub _get_imunify_landing_page {
+    my ($self) = @_;
+    return $self->base_path('cgi/imunify/handlers/index.cgi');
+}
+
 sub _get_purchase_and_install_template {
     return << 'TEMPLATE';
 [%- locale.maketext('Use [asis,Imunify360] for a comprehensive suite of protection against attacks on your servers.') %]
@@ -264,23 +269,19 @@ sub _suggest_imunify360 {
         );
     }
     else {
-        my $imunify_whm_link = locale()->maketext(
-            '[output,url,_1,Open Imunify360,_2,_3].',
-            $self->base_path('/cgi/imunify/handlers/index.cgi'),
-            'target' => '_parent'
-        );
 
         $self->add_good_advice(
-            key        => 'Imunify360_present',
-            text       => locale()->maketext(q{Your server is protected by [asis,Imunify360].}),
-            suggestion => locale()->maketext(
-                q{For help getting started, read [output,url,_1,Imunify360’s documentation,_2,_3].},
-                'https://go.cpanel.net/imunify360gettingstarted',
-                'target' => '_blank',
-              )
-              . '<br><br>'
-              . $imunify_whm_link,
-            block_notify => 1,    # Do not send a notification about this
+            key          => 'Imunify360_present',
+            text         => locale()->maketext(q{Your server is protected by [asis,Imunify360].}),
+            block_notify => 1,                                                                                                                              # Do not send a notification about this
+            infolink     => {
+                text => locale()->maketext('For help getting started, read the [asis,Imunify360] documentation'),
+                link => 'https://go.cpanel.net/imunify360gettingstarted',
+            },
+            landingpage => {
+                text => locale()->maketext('Open Imunify360.'),
+                link => $self->_get_imunify_landing_page(),
+            },
         );
     }
 
@@ -290,10 +291,26 @@ sub _suggest_imunify360 {
 sub _suggest_iav {
     my ($self) = @_;
 
-    if ( !$self->{iav}{installed} && !$self->{iavp}{licensed} ) {
+    if ( $self->{iav}{installed} && !$self->{iavp}{licensed} ) {
+        $self->add_good_advice(
+            key          => 'ImunifyAV_present',
+            text         => locale()->maketext(q{Your server is protected by [asis,ImunifyAV].}),
+            block_notify => 1,
+            infolink     => {
+                text => locale()->maketext('For help getting started, read the [asis,ImunifyAV] documentation.'),
+                link => 'https://docs.imunifyav.com/imunifyav/'
+            },
+            landingpage => {
+                text => locale()->maketext('Go to [asis,ImunifyAV].'),
+                link => $self->_get_imunify_landing_page(),
+            },
+        );
+    }
+    elsif ( !$self->{iav}{installed} && !$self->{iavp}{licensed} ) {
         $self->_avplus_advice( action => 'installav', advice => 'bad' );
     }
-    elsif ( $self->{iav}{installed} ) {
+
+    if ( $self->{iav}{installed} && _can_load_module('Cpanel::RPM') ) {
 
         require Cpanel::RPM;
         my $rpm = Cpanel::RPM->new();
@@ -322,10 +339,20 @@ sub _suggest_iavp {
         $self->_avplus_advice( action => 'installplus', advice => 'bad' );
     }
     elsif ( $self->{iavp}{installed} && $self->{iavp}{licensed} ) {
+        my $landingpage_url = $self->base_path('cgi/imunify/handlers/index.cgi');
+
         $self->add_good_advice(
             key          => 'ImunifyAV+_present',
             text         => locale()->maketext(q{Your server is protected by [asis,ImunifyAV+].}),
             block_notify => 1,
+            infolink     => {
+                text => locale()->maketext('For help getting started, read the [asis,ImunifyAV+] documentation.'),
+                link => 'https://docs.imunifyav.com/imunifyav/'
+            },
+            landingpage => {
+                text => locale()->maketext('Go to [asis,ImunifyAV+].'),
+                link => $self->_get_imunify_landing_page(),
+            },
         );
     }
 

--- a/pkg/templates/main.tmpl
+++ b/pkg/templates/main.tmpl
@@ -101,6 +101,16 @@ END; %]
             {{suggestion}}
         </p>
         {{/if}}
+        {{#if landingpage}}
+        <p>
+            <a href={{landingpage.link}} target=_parent>{{landingpage.text}}<a/>
+        </p>
+        {{/if}}
+        {{#if infolink}}
+        <p>
+            <a href={{infolink.link}} target=_blank>{{infolink.text}}<a/>
+        </p>
+        {{/if}}
     </div>
 </script>
 <script id="item-template-warn" type="text/x-handlebars-template">
@@ -276,9 +286,21 @@ Scanner.prototype.parse_comet_message = function(data) {
         var container = document.getElementById(id);
         var advice = data.advice;
         advice.messageId = YAHOO.lang.escapeHTML(advice.key);
+
         if (advice.suggestion) {
             advice.suggestion = new window.Handlebars.SafeString(advice.suggestion);
         }
+
+        if (advice.infolink) {
+            advice.infolink.text = new window.Handlebars.SafeString(advice.infolink.text);
+            advice.infolink.link = new window.Handlebars.SafeString(advice.infolink.link);
+        }
+
+        if (advice.landingpage) {
+            advice.landingpage.text = new window.Handlebars.SafeString(advice.landingpage.text);
+            advice.landingpage.link = new window.Handlebars.SafeString(advice.landingpage.link);
+        }
+
         advice.text = new window.Handlebars.SafeString(advice.text);
 
         var messageEl = document.createElement('div');


### PR DESCRIPTION
Case BWG-1444

If the Imunify product checks return good advice, we now provide a link
to the landing page in WHM along with a link to the Imunify
documentation.

Changelog: