### PR TITLE
Report conditions leading to inaccurate advice

### DIFF
--- a/pkg/Cpanel/Security/Advisor.pm
+++ b/pkg/Cpanel/Security/Advisor.pm
@@ -1,6 +1,6 @@
 package Cpanel::Security::Advisor;
 
-# Copyright (c) 2016, cPanel, Inc.
+# Copyright (c) 2020, cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net
 #
@@ -202,7 +202,7 @@ sub generate_advice {
     my ($self) = @_;
 
     $self->_internal_message( { type => 'scan_run', state => 0 } );
-    foreach my $mod ( @{ $self->{'assessors'} } ) {
+    foreach my $mod ( sort { lc $a->{'name'} cmp lc $b->{'name'} } @{ $self->{'assessors'} } ) {
         my $module         = $mod->{'name'};
         my $version_ref    = "$module"->can('version');
         my $module_version = $version_ref ? $version_ref->() : '';

--- a/pkg/Cpanel/Security/Advisor/Assessors/_Self.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/_Self.pm
@@ -1,0 +1,89 @@
+package Cpanel::Security::Advisor::Assessors::_Self;
+
+# Copyright (c) 2020, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL cPanel, L.L.C. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+use base 'Cpanel::Security::Advisor::Assessors';
+
+use Cpanel::RPM::Versions::File ();
+
+# The purpose of this assessor module is to report conditions which may render
+# the provided advice untrustworthy or invalid. Currently, this is limited to
+# determining whether the RPM database is acting as expected, since several
+# other assessors rely on good RPM data.
+
+# Logic behind this number: A barebones CentOS 6 container has 129(?) RPM packages.
+# Round down to one significant figure.
+use constant OS_RPM_COUNT_WARN_THRESHOLD => 100;
+
+sub version { return '1.00'; }
+
+sub generate_advice {
+    my ($self) = @_;
+
+    $self->_check_rpm();
+
+    return 1;
+}
+
+sub _check_rpm {
+    my ($self) = @_;
+
+    # Both primes the cache and ensures that the test is run.
+    my $installed_rpms = $self->get_installed_rpms();
+
+    my $cache = $self->{'security_advisor_obj'}->{'_cache'};
+    if ( exists $cache->{'timed_out'} && $cache->{'timed_out'} ) {
+        $self->add_bad_advice(
+            'key'          => 'RPM_timed_out',
+            'text'         => $self->_lh->maketext('Security Advisor timed out while reading the RPM database of packages.'),
+            'suggestion'   => $self->_lh->maketext( "Security Advisor may include inaccurate results until it can fully read the RPM database. To resolve this, reduce the load on your system and then rebuild the RPM database with the following interface: [output,url,_1,Rebuild RPM Database,_2,_3].", $self->base_path('scripts/dialog?dialog=rebuildrpmdb'), 'target', '_blank' ),
+            'block_notify' => 1,
+        );
+    }
+    elsif ( exists $cache->{'died'} && $cache->{'died'} ) {
+        $self->add_bad_advice(
+            'key'          => 'RPM_broken',
+            'text'         => $self->_lh->maketext('Security Advisor detected RPM database corruption.'),
+            'suggestion'   => $self->_lh->maketext( "Security Advisor may include inaccurate results until it can cleanly read the RPM database. To resolve this, rebuild the RPM database with the following interface: [output,url,_1,Rebuild RPM Database,_2,_3].", $self->base_path('scripts/dialog?dialog=rebuildrpmdb'), 'target', '_blank' ),
+            'block_notify' => 1,
+        );
+    }
+    elsif ( ref $installed_rpms eq 'HASH' && scalar keys %$installed_rpms <= scalar( keys %{ Cpanel::RPM::Versions::File->new()->list_rpms_in_state('installed') } ) + OS_RPM_COUNT_WARN_THRESHOLD ) {
+        $self->add_warn_advice(
+            'key'          => 'RPM_too_few',
+            'text'         => $self->_lh->maketext('The RPM database is smaller than expected.'),
+            'suggestion'   => $self->_lh->maketext("Security Advisor may include inaccurate results if the RPM database of packages is incomplete. To resolve this, check the cPanel update logs for RPM issues."),
+            'block_notify' => 1,
+        );
+    }
+
+    return;
+}
+
+1;

--- a/t/pkg-Cpanel-Security-Advisor-Assessors-_Self.t
+++ b/t/pkg-Cpanel-Security-Advisor-Assessors-_Self.t
@@ -1,0 +1,161 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+# Copyright (c) 2020, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL cPanel, L.L.C. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../pkg";
+
+use Test::More;
+use Test::Deep;
+use Test::MockModule 'strict';
+
+use Test::Assessor ();
+
+use Cpanel::Exception ();
+use Cpanel::Locale    ();
+use Cpanel::Version   ();
+
+use Cpanel::Security::Advisor                   ();
+use Cpanel::Security::Advisor::Assessors        ();
+use Cpanel::Security::Advisor::Assessors::_Self ();
+
+plan skip_all => 'Requires cPanel & WHM v66 or later' if Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.65' );
+plan tests    => 4;
+
+# Suppress warning from base_path():
+$ENV{'REQUEST_URI'} = '';
+
+can_ok( 'Cpanel::Security::Advisor::Assessors::_Self', qw(version generate_advice) );
+
+subtest 'RPM times out' => sub {
+    plan tests => 1;
+
+    # Mock for `rpm -qa` for when the program times out.
+    my $mock_saferun = Test::MockModule->new('Cpanel::SafeRun::Full');
+    $mock_saferun->redefine(
+        run => sub {
+            return {
+                'did_dump_core'    => 0,
+                'died_from_signal' => 15,
+                'exit_value'       => 0,
+                'message'          => 'Executed /usr/bin/rpm -qa --queryformat %{NAME} %{VERSION}-%{RELEASE}\\n',
+                'status'           => 1,
+                'stderr'           => '',
+                'stdout'           => '',
+                'timeout'          => 1,
+            };
+        }
+    );
+    my $expected = {
+        'type' => $Cpanel::Security::Advisor::ADVISE_BAD,
+        'key'  => 'RPM_timed_out',
+        'text' => Cpanel::Locale::lh()->maketext('Security Advisor timed out while reading the RPM database of packages.'),
+        'suggestion' =>
+          Cpanel::Locale::lh()->maketext( "Security Advisor may include inaccurate results until it can fully read the RPM database. To resolve this, reduce the load on your system and then rebuild the RPM database with the following interface: [output,url,_1,Rebuild RPM Database,_2,_3].", Cpanel::Security::Advisor::Assessors->base_path('scripts/dialog?dialog=rebuildrpmdb'), 'target', '_blank' ),
+        'block_notify' => 1,
+    };
+    cmp_assessor( '_Self', [$expected], 'Error displayed' );
+};
+
+subtest 'RPM crashes' => sub {
+    plan tests => 1;
+
+    # Mock for `rpm -qa` for when the program dies abnormally.
+    my $mock_saferun = Test::MockModule->new('Cpanel::SafeRun::Full');
+    $mock_saferun->redefine(
+        run => sub {
+            return {
+                'did_dump_core'    => 0,
+                'died_from_signal' => 6,
+                'exit_value'       => 0,
+                'message'          => 'Executed /usr/bin/rpm -qa --queryformat %{NAME} %{VERSION}-%{RELEASE}\\n',
+                'status'           => 1,
+                'stderr'           => '',
+                'stdout'           => '',
+                'timeout'          => undef,
+            };
+        }
+    );
+    my $expected = {
+        'type'         => $Cpanel::Security::Advisor::ADVISE_BAD,
+        'key'          => 'RPM_broken',
+        'text'         => Cpanel::Locale::lh()->maketext('Security Advisor detected RPM database corruption.'),
+        'suggestion'   => Cpanel::Locale::lh()->maketext( "Security Advisor may include inaccurate results until it can cleanly read the RPM database. To resolve this, rebuild the RPM database with the following interface: [output,url,_1,Rebuild RPM Database,_2,_3].", Cpanel::Security::Advisor::Assessors->base_path('scripts/dialog?dialog=rebuildrpmdb'), 'target', '_blank' ),
+        'block_notify' => 1,
+    };
+    cmp_assessor( '_Self', [$expected], 'Error displayed' );
+};
+
+subtest 'RPM is incomplete' => sub {
+    plan tests => 1;
+
+    my $mock_saferun = Test::MockModule->new('Cpanel::SafeRun::Full');
+    $mock_saferun->redefine(
+        run => sub {
+            return {
+                'did_dump_core'    => 0,
+                'died_from_signal' => 0,
+                'exit_value'       => 0,
+                'message'          => 'Executed /usr/bin/rpm -qa --queryformat %{NAME} %{VERSION}-%{RELEASE}\\n',
+                'status'           => 1,
+                'stderr'           => '',
+                'stdout'           => "pkg-1.0-1.el7.x86_64\n" x 500,
+                'timeout'          => undef,
+            };
+        }
+    );
+    my $expected = {
+        'type'         => $Cpanel::Security::Advisor::ADVISE_WARN,
+        'key'          => 'RPM_too_few',
+        'text'         => Cpanel::Locale::lh()->maketext('The RPM database is smaller than expected.'),
+        'suggestion'   => Cpanel::Locale::lh()->maketext("Security Advisor may include inaccurate results if the RPM database of packages is incomplete. To resolve this, check the cPanel update logs for RPM issues."),
+        'block_notify' => 1,
+    };
+    cmp_assessor( '_Self', [$expected], 'Error displayed' );
+};
+
+sub cmp_assessor {
+    my ( $assessor, $expected_advice, $msg ) = @_;
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    my $object = Test::Assessor->new( assessor => $assessor );
+    $object->generate_advice();
+
+    my $got = $object->get_advice();
+    $object->clear_advice();
+
+    my @expected = map { { module => "Cpanel::Security::Advisor::Assessors::$assessor", function => ignore(), advice => $_ } } @$expected_advice;
+
+    my $ret = cmp_deeply( $got, \@expected, $msg );
+    diag explain $got if !$ret;
+
+    return $ret;
+}


### PR DESCRIPTION
Case CPANEL-32705: Certain advisors reply upon a functional and accurate
RPM database to give accurate results. If an attempt to fetch the list
of packages exits abnormally, times out, or contains far fewer entries
than expected, raise appropriate advice recommending addressing this
issue. Additionally, modify the run order of assessors so that the new
assessor runs first.