### PR TITLE
Fix module load error reporting

### DIFF
--- a/t/lib/Cpanel/Security/Advisor/Assessors/MockAssessor.pm
+++ b/t/lib/Cpanel/Security/Advisor/Assessors/MockAssessor.pm
@@ -1,0 +1,63 @@
+package Cpanel::Security::Advisor::Assessors::MockAssessor;
+
+# Copyright (c) 2020, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL cPanel, L.L.C. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+use base 'Cpanel::Security::Advisor::Assessors';
+
+
+sub version {
+    return '9.99';
+}
+
+sub generate_advice {
+    my ($self) = @_;
+    $self->add_good_advice(
+        'key'        => 'example_good_advice',
+        'text'       => 'This is good.',
+        'suggestion' => 'A suggestion.'
+    );
+    $self->add_info_advice(
+        'key'        => 'example_info_advice',
+        'text'       => 'This is info.',
+        'suggestion' => 'A suggestion.'
+    );
+    $self->add_warn_advice(
+        'key'        => 'example_warn_advice',
+        'text'       => 'This is a warning.',
+        'suggestion' => 'A suggestion.'
+    );
+    $self->add_bad_advice(
+        'key'        => 'example_bad_advice',
+        'text'       => 'This is bad.',
+        'suggestion' => 'A suggestion.'
+    );
+    return 1;
+}
+
+1;

--- a/t/lib/Cpanel/Security/Advisor/Assessors/MockLoadFail.pm
+++ b/t/lib/Cpanel/Security/Advisor/Assessors/MockLoadFail.pm
@@ -1,0 +1,35 @@
+package Cpanel::Security::Advisor::Assessors::MockLoadFail;
+
+# Copyright (c) 2020, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL cPanel, L.L.C. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+use base 'Cpanel::Security::Advisor::Assessors';
+
+die 'No assessor for you!';
+
+1;

--- a/t/lib/Cpanel/Security/Advisor/Assessors/MockNewFail.pm
+++ b/t/lib/Cpanel/Security/Advisor/Assessors/MockNewFail.pm
@@ -1,0 +1,37 @@
+package Cpanel::Security::Advisor::Assessors::MockNewFail;
+
+# Copyright (c) 2020, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL cPanel, L.L.C. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+use base 'Cpanel::Security::Advisor::Assessors';
+
+sub new {
+    die 'No new for you!';
+}
+
+1;

--- a/t/lib/Test/Mock/SecurityAdvisor.pm
+++ b/t/lib/Test/Mock/SecurityAdvisor.pm
@@ -1,0 +1,152 @@
+package Test::Mock::SecurityAdvisor;
+
+# Copyright (c) 2020, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL cPanel, L.L.C. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+use Test::MockModule qw/strict/;
+use Test::MockFile;
+
+use Cpanel::Comet::Mock       ();
+use Cpanel::JSON              ();
+use Cpanel::Security::Advisor ();
+
+use constant {
+    COMET_CHANNEL => 'securityadvisor',
+};
+
+sub new {
+    return bless {
+        '_comet' => Cpanel::Comet::Mock->new(),
+      },
+      __PACKAGE__;
+}
+
+sub new_advisor_object {
+    my ($self) = @_;
+    return Cpanel::Security::Advisor->new( 'comet' => $self->{'_comet'}, 'channel' => COMET_CHANNEL() );
+}
+
+sub mock_all {
+    my ($self) = @_;
+
+    $self->set_assessor_module('Cpanel::Security::Advisor::Assessors::MockAssessor');
+
+    $self->mock_func(
+        'Cpanel::Logger',
+        'warn' => sub {
+
+            # For testing CPANEL-33980. Clobber $@ a.k.a. $EVAL_ERROR because that's what Cpanel::Logger does.
+            eval { die 'Not what you expected, grasshopper?' };
+            return 1;
+        }
+    );
+
+    $self->mock_func(
+        'Cpanel::LoadModule',
+        'load_perl_module' => sub {
+            my $module = shift;
+            if ( index( $module, 'Cpanel::Security::Advisor::Assessors' ) >= 0 && index( $module, 'Mock' ) == -1 ) {
+                die "Attempting to load an unmocked assessor module: $module";
+            }
+
+            # Otherwise, make a real attempt to load the module.
+            return $self->get_mock_module('Cpanel::LoadModule')->original('load_perl_module')->($module);
+        }
+    );
+
+    return;
+}
+
+sub set_assessor_module {
+    my ( $self, $module ) = @_;
+    $self->mock_func(
+        'Cpanel::LoadModule::AllNames',
+        'get_loadable_modules_in_namespace' => sub {
+            return { $module => 'testing' };
+        }
+    );
+    return;
+}
+
+sub get_advisor_messages {
+    my ($self) = @_;
+    my @decoded;
+    for my $msg ( @{ $self->{'_comet'}->get_messages( COMET_CHANNEL() ) } ) {
+        push @decoded, Cpanel::JSON::Load($msg);
+    }
+    return \@decoded;
+}
+
+sub get_mock_module {
+    my ( $self, $module ) = @_;
+    die "No mock for $module exists" unless exists $self->{'_module'}->{$module};
+    return $self->{'_module'}->{$module};
+}
+
+sub get_func_calls {
+    my ( $self, $module, $func ) = @_;
+    die "No mock for ${module}::${func} exists" unless exists $self->{'_module'}->{$module} && $self->{'_module'}->{$module}->is_mocked($func);
+    return $self->{'_calls'}->{$module}->{$func};
+}
+
+sub mock_func {
+    my ( $self, $module, $func, $impl ) = @_;
+    if ( !exists $self->{'_module'}->{$module} ) {
+        $self->{'_module'}->{$module} = Test::MockModule->new($module);
+    }
+    @{ $self->{'_calls'}->{$module}->{$func} } = ();
+    $self->{'_module'}->{$module}->redefine(
+        $func => sub {
+            push @{ $self->{'_calls'}->{$module}->{$func} }, [@_];
+            if ( ref $impl eq 'CODE' ) {
+                return $impl->(@_);
+            }
+            return $impl;
+        }
+    );
+    return $self->{'_module'}->{$module};
+}
+
+sub mock_file {
+    my ( $self, $dir, $file, $contents ) = @_;
+    my $fullpath = $dir . q{/} . $file;
+
+    if ( exists $self->{'_file'}->{$dir} ) {
+        $self->{'_file'}->{$dir}->contents( [ sort( @{ $self->{'_file'}->{$dir}->contents() }, $file ) ] );
+    }
+    else {
+        $self->{'_file'}->{$dir} = Test::MockFile->dir( $dir, [$file] );
+    }
+
+    $self->{'_file'}->{$fullpath} = Test::MockFile->file( $fullpath, $contents );
+
+    return;
+}
+
+1;

--- a/t/pkg-Cpanel-Security-Advisor.t
+++ b/t/pkg-Cpanel-Security-Advisor.t
@@ -1,0 +1,245 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+# Copyright (c) 2020, cPanel, L.L.C.
+# All rights reserved.
+# http://cpanel.net
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the owner nor the names of its contributors may
+#       be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL cPanel, L.L.C. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../pkg";
+
+use Test::More;
+use Test::Deep;
+use Test::Exception;
+
+use Test::Mock::SecurityAdvisor;
+
+use Cpanel::Version ();
+
+use Cpanel::Security::Advisor ();
+
+plan skip_all => 'Requires cPanel & WHM v86 or later' if Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.85' );
+plan tests    => 4;
+
+can_ok( 'Cpanel::Security::Advisor', qw(new generate_advice add_advice) );
+
+subtest 'happy path' => sub {
+    plan tests => 3;
+
+    my $mock = Test::Mock::SecurityAdvisor->new();
+    $mock->mock_all();
+
+    my $advisor = $mock->new_advisor_object();
+    lives_ok { $advisor->generate_advice() } 'generate_advice() lives in the happy path.';
+
+    my $advisor_messages = $mock->get_advisor_messages();
+
+    my @expected_msgs = map {
+        {
+            'channel' => 'securityadvisor',
+            'data'    => $_,
+        }
+    } (
+        {
+            'module'  => 'Cpanel::Security::Advisor::Assessors::MockAssessor',
+            'runtime' => 1,
+            'state'   => 1,
+            'type'    => 'mod_load'
+        },
+        {
+            'state' => 0,
+            'type'  => 'scan_run'
+        },
+        {
+            'module'  => 'Cpanel::Security::Advisor::Assessors::MockAssessor',
+            'state'   => 0,
+            'type'    => 'mod_run',
+            'version' => '9.99'
+        },
+        {
+            'advice' => {
+                'key'        => 'example_good_advice',
+                'suggestion' => 'A suggestion.',
+                'text'       => 'This is good.',
+                'type'       => 1
+            },
+            'function' => 'generate_advice',
+            'module'   => 'Cpanel::Security::Advisor::Assessors::MockAssessor',
+            'type'     => 'mod_advice'
+        },
+        {
+            'advice' => {
+                'key'        => 'example_info_advice',
+                'suggestion' => 'A suggestion.',
+                'text'       => 'This is info.',
+                'type'       => 2
+            },
+            'function' => 'generate_advice',
+            'module'   => 'Cpanel::Security::Advisor::Assessors::MockAssessor',
+            'type'     => 'mod_advice'
+        },
+        {
+            'advice' => {
+                'key'        => 'example_warn_advice',
+                'suggestion' => 'A suggestion.',
+                'text'       => 'This is a warning.',
+                'type'       => 4
+            },
+            'function' => 'generate_advice',
+            'module'   => 'Cpanel::Security::Advisor::Assessors::MockAssessor',
+            'type'     => 'mod_advice'
+        },
+        {
+            'advice' => {
+                'key'        => 'example_bad_advice',
+                'suggestion' => 'A suggestion.',
+                'text'       => 'This is bad.',
+                'type'       => 8
+            },
+            'function' => 'generate_advice',
+            'module'   => 'Cpanel::Security::Advisor::Assessors::MockAssessor',
+            'type'     => 'mod_advice'
+        },
+        {
+            'message' => '',
+            'module'  => 'Cpanel::Security::Advisor::Assessors::MockAssessor',
+            'state'   => 1,
+            'type'    => 'mod_run',
+            'version' => '9.99'
+        },
+        {
+            'state' => 1,
+            'type'  => 'scan_run'
+        }
+    );
+
+    cmp_deeply( $advisor_messages, \@expected_msgs, 'Got expected messages in the happy path.' ) or diag explain $advisor_messages;
+
+    my $logged_warnings = $mock->get_func_calls( 'Cpanel::Logger', 'warn' );
+
+    cmp_deeply( $logged_warnings, [], 'No logged warnings in the happy path.' ) or diag explain $logged_warnings;
+
+    return;
+};
+
+subtest 'handle module load exception' => sub {
+    plan tests => 4;
+
+    my $mock = Test::Mock::SecurityAdvisor->new();
+    $mock->mock_all();
+
+    $mock->set_assessor_module('Cpanel::Security::Advisor::Assessors::MockLoadFail');
+
+    my $advisor;
+    lives_ok { $advisor = $mock->new_advisor_object() } 'new() lives when there is a module load exception.';
+    lives_ok { $advisor->generate_advice() } 'generate_advice() lives when there is a module load exception.';
+
+    my @expected_msgs = map {
+        {
+            'channel' => 'securityadvisor',
+            'data'    => $_,
+        }
+    } (
+        {
+            'message' => re('The system failed to load the module'),
+            'module'  => 'Cpanel::Security::Advisor::Assessors::MockLoadFail',
+            'state'   => 0,
+            'type'    => 'mod_load'
+        },
+        {
+            'state' => 0,
+            'type'  => 'scan_run'
+        },
+        {
+            'state' => 1,
+            'type'  => 'scan_run'
+        }
+    );
+
+    my $advisor_messages = $mock->get_advisor_messages();
+    cmp_deeply( $advisor_messages, \@expected_msgs, 'Got expected messages when there is a module new exception.' ) or diag explain $advisor_messages;
+
+    my $logged_warnings = $mock->get_func_calls( 'Cpanel::Logger', 'warn' );
+    cmp_deeply(
+        $logged_warnings,
+        [
+            [ isa('Cpanel::Logger'), re('The system failed to load the module') ],
+        ],
+        'Got expected logged warnings when there is a module load exception.'
+    ) or diag explain $logged_warnings;
+
+    return;
+};
+
+subtest 'handle assessor->new() exception' => sub {
+    plan tests => 4;
+
+    my $mock = Test::Mock::SecurityAdvisor->new();
+    $mock->mock_all();
+
+    $mock->set_assessor_module('Cpanel::Security::Advisor::Assessors::MockNewFail');
+
+    my $advisor;
+    lives_ok { $advisor = $mock->new_advisor_object() } 'new() lives when there is an assessor->new() exception.';
+    lives_ok { $advisor->generate_advice() } 'generate_advice() lives when there is an assessor->new() exception.';
+
+    my @expected_msgs = map {
+        {
+            'channel' => 'securityadvisor',
+            'data'    => $_,
+        }
+    } (
+        {
+            'message' => re('No new for you!'),
+            'module'  => 'Cpanel::Security::Advisor::Assessors::MockNewFail',
+            'state'   => 0,
+            'type'    => 'mod_load'
+        },
+        {
+            'state' => 0,
+            'type'  => 'scan_run'
+        },
+        {
+            'state' => 1,
+            'type'  => 'scan_run'
+        }
+    );
+
+    my $advisor_messages = $mock->get_advisor_messages();
+    cmp_deeply( $advisor_messages, \@expected_msgs, 'Got expected messages when there is an assessor->new() exception.' ) or diag explain $advisor_messages;
+
+    my $logged_warnings = $mock->get_func_calls( 'Cpanel::Logger', 'warn' );
+    cmp_deeply(
+        $logged_warnings,
+        [
+            [ isa('Cpanel::Logger'), re('No new for you!') ],
+        ],
+        'Got expected logged warnings when there is an assessor->new() exception.'
+    ) or diag explain $logged_warnings;
+
+    return;
+};


### PR DESCRIPTION
Case CPANEL-33980: Ensure that assessor module load errors are passed
correctly to the advisor output even if the logger clobbers EVAL_ERROR.

Use a better method to search for and load the assessor modules.