### PR TITLE
Improve check to determine that cagefs is enabled

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors.pm
@@ -1,6 +1,6 @@
 package Cpanel::Security::Advisor::Assessors;
 
-# Copyright (c) 2020, cPanel, L.L.C.
+# Copyright (c) 2021, cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net
 #
@@ -165,6 +165,36 @@ sub get_running_kernel_type {
 sub _lh {
     my ($self) = @_;
     return $self->{'security_advisor_obj'}{'locale'};
+}
+
+sub get_cagefsctl_bin {
+    my ($self) = @_;
+
+    my @bins = (
+        '/usr/bin/cagefsctl',
+        '/usr/sbin/cagefsctl',
+    );
+
+    foreach my $bin (@bins) {
+        return $bin if ( -x $bin );
+    }
+
+    return;
+}
+
+sub cagefs_is_enabled {
+    my ($self) = @_;
+
+    my $cagefsctl = $self->get_cagefsctl_bin();
+    return 0 unless $cagefsctl;
+
+    require Cpanel::SafeRun::Object;
+    my $run = Cpanel::SafeRun::Object->new(
+        program => $cagefsctl,
+        args    => ["--cagefs-status"]
+    );
+
+    return ( $run->stdout() =~ /enabled/i ) ? 1 : 0;
 }
 
 1;

--- a/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Apache.pm
@@ -1,6 +1,6 @@
 package Cpanel::Security::Advisor::Assessors::Apache;
 
-# Copyright (c) 2018, cPanel, L.L.C.
+# Copyright (c) 2021, cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net
 #
@@ -84,7 +84,7 @@ sub _check_for_apache_chroot {
             }
         );
     }
-    elsif ( -x '/usr/bin/cagefsctl' || -x '/usr/sbin/cagefsctl' ) {
+    elsif ( $self->cagefs_is_enabled() ) {
         $security_advisor_obj->add_advice(
             {
                 'key'  => 'Apache_cagefs_is_enabled',

--- a/pkg/Cpanel/Security/Advisor/Assessors/Jail.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Jail.pm
@@ -1,6 +1,6 @@
 package Cpanel::Security::Advisor::Assessors::Jail;
 
-# Copyright (c) 2013, cPanel, Inc.
+# Copyright (c) 2021, cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net
 #
@@ -46,7 +46,7 @@ sub _check_for_unjailed_users {
 
     my $security_advisor_obj = $self->{'security_advisor_obj'};
 
-    if ( !-x '/usr/bin/cagefsctl' && !-x '/usr/sbin/cagefsctl' ) {
+    if ( $self->cagefs_is_enabled() ) {
         if ( -e '/var/cpanel/conf/jail/flags/mount_usr_bin_suid' ) {
             $security_advisor_obj->add_advice(
                 {
@@ -64,7 +64,7 @@ sub _check_for_unjailed_users {
         }
 
         Cpanel::PwCache::init_passwdless_pwcache();
-        my %cpusers = map { $_ => undef } Cpanel::Config::Users::getcpusers();
+        my %cpusers          = map { $_ => undef } Cpanel::Config::Users::getcpusers();
         my %wheel_users_hash = map { $_ => 1 } split( ' ', ( getgrnam('wheel') )[3] );
         delete $wheel_users_hash{'root'};    # We don't care about root being in the wheel group
 


### PR DESCRIPTION
Case CPANEL-35822:

* Previously, the check only ensured that a cagefsctl binary was present
* and executable.  This check is insufficient since cagefs could be
* installed but disabled.  In order to verify that cagefs is properly
* enabled, we now verify that the binary is present, and check to see if
* the cagefs reports as being enabled

Changelog:  Improve check to determine that cagefs is enabled