### PR TITLE
Use Cpanel::OS instead of Cpanel::Sys::OS::Check::get_strict_centos_version

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -34,8 +34,8 @@ use Cpanel::Config::Sources ();
 use Cpanel::Version         ();
 use Cpanel::HTTP::Client    ();
 use Cpanel::JSON            ();
+use Cpanel::OS              ();
 use Cpanel::SafeRun::Object ();
-use Cpanel::Sys::OS::Check  ();
 use Cpanel::Template        ();
 use Cpanel::LoadModule      ();
 
@@ -392,7 +392,7 @@ sub _avplus_advice {
 }
 
 sub _needs_kernelcare {
-    my $centos_version = Cpanel::Sys::OS::Check::get_strict_centos_version();
+    my $centos_version = Cpanel::OS->instance()->major();
 
     # This is only needed on CentOS 6 and 7. CloudLinux already has symlink protection built in,
     # and other distros (RHEL, Amazon Linux, etc.) are not supported.


### PR DESCRIPTION
Case CPANEL-37594:  Cpanel::Sys::OS::Check::get_strict_centos_version
was removed in version 98 in favor of Cpanel::OS.  This updates the
Imunify360 assessor to use Cpanel::OS.

Changelog:  Use Cpanel::OS instead of Cpanel::Sys::OS::Check::get_strict_centos_version