### PR TITLE
Check IPv6 status as part of firewall check

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Mysql.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Mysql.pm
@@ -30,6 +30,7 @@ use strict;
 use Cpanel::Hostname                ();
 use Cpanel::IP::Loopback            ();
 use Cpanel::IP::Parse               ();
+use Cpanel::IPv6::Has               ();
 use Cpanel::MysqlUtils              ();
 use Cpanel::MysqlUtils::MyCnf::Full ();
 use Cpanel::SafeRun::Errors         ();
@@ -190,7 +191,7 @@ sub _check_for_public_bind_address {
         }
     }
     else {
-        if ( ( @deny_rules && @deny_rules_6 ) || ( csf_port_closed($port) ) ) {
+        if ( ( @deny_rules && ( !Cpanel::IPv6::Has::system_has_ipv6() || @deny_rules_6 ) ) || ( csf_port_closed($port) ) ) {
             $self->add_good_advice(
                 'key'  => 'Mysql_port_blocked_by_firewall_2',
                 'text' => $self->_lh->maketext("The MySQL port is blocked by the firewall, effectively allowing only local connections.")


### PR DESCRIPTION
Case CPANEL-37936: In order to verify that the MySQL port was blocked in
the firewall, we would check that it was blocked for both IPv4 and IPv6
addresses.  However, this could result in us giving bad advice in the
event that IPv6 was disabled in the kernel since there would be no need
to block the MySQL port for IPv6 in that instance.  This change ensures
that IPv6 is enabled as part of the firewall check.

Changelog: Check IPv6 status as part of firewall check