### PR TITLE
Adjust notice about removal of ClamAV when ImunifyAV is installed.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors.pm
@@ -96,6 +96,7 @@ sub get_available_rpms {
 
     return $cache->{'available_rpms'} if $cache->{'available_rpms'};
 
+    require Cpanel::FindBin;
     my $output = Cpanel::SafeRun::Full::run(
         'program' => Cpanel::FindBin::findbin('yum'),
         'args'    => [qw/-d 0 list all/],
@@ -122,6 +123,7 @@ sub get_installed_rpms {
 
     return $cache->{'installed_rpms'} if $cache->{'installed_rpms'};
 
+    require Cpanel::FindBin;
     my $output = Cpanel::SafeRun::Full::run(
         'program' => Cpanel::FindBin::findbin('rpm'),
         'args'    => [ '-qa', '--queryformat', '%{NAME} %{VERSION}-%{RELEASE}\n' ],

--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -68,7 +68,7 @@ sub generate_advice {
 
         }
 
-        # These checks will only run on v88 and highger.
+        # These checks will only run on v88 and higher.
         if (   Cpanel::Version::compare( $cpanel_version, '>=', $IMUNIFYAV_MINIMUM_CPWHM_VERSION )
             && $self->{i360}
             && !$self->{i360}{installed} ) {
@@ -277,17 +277,20 @@ sub _suggest_iav {
 
     }
 
-    if ( $self->{iav}{installed} && _can_load_module('Cpanel::RPM') ) {
+    if ( $self->{iav}{installed} ) {
+        my $rpm = _can_load_module('Cpanel::Binaries::Rpm')
+          ? Cpanel::Binaries::Rpm->new()                            # 98+
+          : _can_load_module('Cpanel::RPM') ? Cpanel::RPM->new()    # 96 and below
+          :                                   undef;
 
-        my $rpm = Cpanel::RPM->new();
-        if ( $rpm->has_rpm('cpanel-clamav') ) {
+        if ( $rpm && $rpm->has_rpm('cpanel-clamav') ) {
 
             my $plugins_url = $self->base_path('scripts2/manage_plugins');
-            $self->add_warn_advice(
+            $self->add_info_advice(
                 'key'          => 'ImunifyAV+_clam_and_iav_installed',
                 'block_notify' => 1,
-                'text'         => locale()->maketext("Uninstall [asis,ClamAV]."),
-                'suggestion'   => locale()->maketext( "[asis,ClamAV] and [asis,ImunifyAV] are both installed. [output,url,_1,Uninstall ClamAV,_2,_3]", $plugins_url, 'target', '_blank' ),
+                'text'         => locale()->maketext("You have both ClamAV and ImunifyAV installed."),
+                'suggestion'   => locale()->maketext( "ImunifyAV and ClamAV both provide antivirus coverage. To conserve resources you may want to [output,url,_1,Uninstall ClamAV,_2,_3]. However, ClamAV allows the “Scan outgoing messages for malware” setting to function. If you use this setting, keep ClamAV installed.", $plugins_url, 'target', '_blank' ),
             );
         }
     }

--- a/t/pkg-Cpanel-Security-Advisor-Assessors-Imunify360.t
+++ b/t/pkg-Cpanel-Security-Advisor-Assessors-Imunify360.t
@@ -95,7 +95,7 @@ my $response_imunify_enabled = Cpanel::HTTP::Client::Response->new(
 );
 $response_imunify_enabled->header( 'Content-Type', 'application/json' );
 
-plan tests => 8 + 1;
+plan tests => 6 + 1;
 
 subtest 'When Imunify360 is disabled' => sub {
     plan tests => 1;
@@ -141,61 +141,18 @@ subtest 'When Imunify360 is not installed or licensed' => sub {
     cmp_deeply( $advice->[0], superhashof($expected), "It should advice buying an Imunify360 license" ) or diag explain $advice;
 };
 
-subtest 'When has a license but Imunify360 is not installed' => sub {
+subtest 'When Imunify360 is installed' => sub {
     plan tests => 1;
 
-    $imunify->redefine( is_imunify360_licensed  => sub { 1 } );
-    $imunify->redefine( is_imunify360_installed => sub { 0 } );
-
-    my $advice   = get_advice();
-    my $expected = {
-        'advice' => {
-            'key'          => 'Imunify360_install',
-            'block_notify' => ignore(),
-            'suggestion'   => ignore(),
-            'text'         => ignore(),
-            'type'         => ignore(),
-        },
-    };
-
-    cmp_deeply( $advice->[0], superhashof($expected), "It should advice to install Imunify360" ) or diag explain $advice;
-};
-
-subtest 'When Imunify360 is installed but not licensed' => sub {
-    plan tests => 1;
-
-    $imunify->redefine( is_imunify360_licensed  => sub { 0 } );
     $imunify->redefine( is_imunify360_installed => sub { 1 } );
 
     my $advice   = get_advice();
     my $expected = {
-        'advice' => {
-            'key'          => 'Imunify360_update_license',
-            'block_notify' => ignore(),
-            'suggestion'   => ignore(),
-            'text'         => ignore(),
-            'type'         => ignore(),
-        },
-    };
-
-    cmp_deeply( $advice->[0], superhashof($expected), "It should advice to renew the license" ) or diag explain $advice;
-};
-
-subtest 'When Imunify360 is installed and licensed' => sub {
-    plan tests => 1;
-
-    $imunify->redefine( is_imunify360_licensed  => sub { 1 } );
-    $imunify->redefine( is_imunify360_installed => sub { 1 } );
-
-    my $advice   = get_advice();
-    my $expected = {
-        'advice' => {
-            'key'          => 'Imunify360_present',
-            'block_notify' => ignore(),
-            'suggestion'   => ignore(),
-            'text'         => ignore(),
-            'type'         => ignore(),
-        },
+        'advice' => superhashof(
+            {
+                'key' => 'Imunify360_present',
+            }
+        ),
     };
 
     cmp_deeply( $advice->[0], superhashof($expected), "It should say that the server is protected" ) or diag explain $advice;

--- a/t/pkg-Cpanel-Security-Advisor-Assessors-Kernel.t
+++ b/t/pkg-Cpanel-Security-Advisor-Assessors-Kernel.t
@@ -35,6 +35,7 @@ use lib "$FindBin::Bin/lib", "$FindBin::Bin/../pkg";
 use Test::More;
 use Test::Deep;
 use Test::MockModule;
+use IO::Pty;
 
 use Test::Assessor ();
 
@@ -42,12 +43,16 @@ use Cpanel::Exception ();
 use Cpanel::Version   ();
 
 plan skip_all => 'Requires cPanel & WHM v66 or later' if Cpanel::Version::compare( Cpanel::Version::getversionnumber(), '<', '11.65' );
-plan tests => 4;
+plan tests    => 4;
 
 my $envtype = Test::MockModule->new('Cpanel::KernelCare');
 $envtype->mock( system_supports_kernelcare => sub { 0 } );    # Disable KernelCare advertisements.
 
 local $ENV{'REQUEST_URI'} = 'mocking out to avoid warnings';
+
+# Avoid maketext failures related to html vs. text context when non-interactive
+my $pty = IO::Pty->new();
+local *STDIN = $pty->slave;
 
 subtest 'Error parsing boot configuration' => sub {
     plan tests => 2;


### PR DESCRIPTION
Case CPANEL-34196: When ImunifyAV (free version) was added to
the product, the Security Advisor was updated to check whether
ClamAV was also installed, and if so, recommend removing it on
the grounds that it would be redundant. ClamAV is not redundant,
however, because it is still required for a setting in WHM that
enables scanning messages that pass through Exim. Instead of plainly
recommending ClamAV's removal, we should add some detail on why it
might (or might not) still be necessary.

This change also updates the RPM check for compatibility with versions
98 and up, which no longer have the Cpanel::RPM module, and fixes
several broken unit tests.