### PR TITLE
Fix ImunifyAV+ advice when Imunify360 is disabled

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -69,9 +69,8 @@ sub generate_advice {
         }
 
         # These checks will only run on v88 and higher.
-        if (   Cpanel::Version::compare( $cpanel_version, '>=', $IMUNIFYAV_MINIMUM_CPWHM_VERSION )
-            && $self->{i360}
-            && !$self->{i360}{installed} ) {
+        if ( Cpanel::Version::compare( $cpanel_version, '>=', $IMUNIFYAV_MINIMUM_CPWHM_VERSION )
+            && !( $self->{i360} && $self->{i360}{installed} ) ) {
 
             if ( _can_load_module('Whostmgr::Store::Product::ImunifyAVPlus') ) {
 


### PR DESCRIPTION
Case CPANEL-37357: Ensure that ImunifyAV+ advice is offered when
Imunify360 is disabled in Manage2. Previously ImunifyAV+ would be
skipped if the i360 object attribute was not initialized, which would
happen when Imunify360 was disabled entirely.