### PR TITLE
Produce an error when RPM isn't functional.

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Imunify360.pm
@@ -101,6 +101,16 @@ sub generate_advice {
     };
     if ( my $exception = $@ ) {
         print STDERR $exception;    # STDERR gets sent to ULC/logs/error_log.
+
+        if ( $exception =~ m{Unable to find the rpm binary} ) {
+            return $self->add_bad_advice(
+                key          => 'Immunify360_rpm_failure',
+                text         => "Unable to determine if Imunify360 is installed",
+                suggestion   => "Ensure that yum and rpm are working on your system.",
+                block_notify => 1,                                                       # Do not send a notification>
+            );
+        }
+
         die $exception;
     }
 


### PR DESCRIPTION
Case CPANEL-38239: If the rpm binary failed to execute for whatever
reason, the imunify360 detection would silently fail (on 100). This
change addresses that by adding some bad advice, letting the user know
RPM is not functional on their system.

Changelog: Inform user when rpm fails to execute during Imunify360
 detection.