### PR TITLE
Avoid uninitialized value warning on legacy Cpanel OS Check

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Processes.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Processes.pm
@@ -32,7 +32,7 @@ use base 'Cpanel::Security::Advisor::Assessors';
 
 use Cpanel::Version ();
 
-my $has_modern_cpanel_os = eval { require Cpanel::OS && $Cpanel::OS::VERSION >= 2 }
+my $has_modern_cpanel_os = eval { require Cpanel::OS && ( $Cpanel::OS::VERSION // 0 ) >= 2 }
   or require Cpanel::Sys::OS::Check;
 
 sub version {


### PR DESCRIPTION
Case CPANEL-38802: Versions of cPanel that pre-date the Cpanel::OS
refactor were generating uninitialized value warnings due to the absence
of $Cpanel::OS::VERSION. This change addresses that by defaulting to 0
when undefined.

Changelog: Avoid uninitialized value warning on systems with legacy
 Cpanel::OS