### PR TITLE
Eliminate invocations of /usr/bin/rpm on non-RPM systems

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors.pm
@@ -29,7 +29,7 @@ package Cpanel::Security::Advisor::Assessors;
 use strict;
 use warnings;
 
-our $VERISON = 1.1;
+our $VERSION = 1.1;
 
 use Cpanel::SafeRun::Full    ();
 use Cpanel::Version::Compare ();
@@ -40,7 +40,7 @@ sub new {
 
     my $self = bless {
         'security_advisor_obj' => $security_advisor_obj,
-        '_version'             => $VERISON
+        '_version'             => $VERSION
     }, $class;
 
     return $self;

--- a/pkg/Cpanel/Security/Advisor/Assessors/SSH.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/SSH.pm
@@ -1,6 +1,6 @@
 package Cpanel::Security::Advisor::Assessors::SSH;
 
-# Copyright (c) 2013, cPanel, Inc.
+# Copyright (c) 2021, cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net
 #
@@ -28,11 +28,12 @@ package Cpanel::Security::Advisor::Assessors::SSH;
 
 use strict;
 use Whostmgr::Services::SSH::Config ();
+use Cpanel::PackMan                 ();
 
 use base 'Cpanel::Security::Advisor::Assessors';
 
 sub version {
-    return '1.01';
+    return '1.02';
 }
 
 sub generate_advice {
@@ -95,11 +96,11 @@ sub _check_for_ssh_settings {
 sub _check_for_ssh_version {
     my ($self) = @_;
 
-    my $installed_rpms = $self->get_installed_rpms();
-    my $available_rpms = $self->get_available_rpms();
+    my $pkm     = Cpanel::PackMan->instance;
+    my $pkginfo = $pkm->pkg_hr('openssh-server');
 
-    my $current_sshversion = $installed_rpms->{'openssh-server'};
-    my $latest_sshversion  = $available_rpms->{'openssh-server'};
+    my $current_sshversion = $pkginfo->{'version_installed'};
+    my $latest_sshversion  = $pkginfo->{'version_latest'};
 
     if ( length $current_sshversion && length $latest_sshversion ) {
         if ( $current_sshversion lt $latest_sshversion ) {

--- a/pkg/Cpanel/Security/Advisor/Assessors/_Self.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/_Self.pm
@@ -1,6 +1,6 @@
 package Cpanel::Security::Advisor::Assessors::_Self;
 
-# Copyright (c) 2020, cPanel, L.L.C.
+# Copyright (c) 2021, cPanel, L.L.C.
 # All rights reserved.
 # http://cpanel.net
 #
@@ -41,12 +41,12 @@ use Cpanel::RPM::Versions::File ();
 # Round down to one significant figure.
 use constant OS_RPM_COUNT_WARN_THRESHOLD => 100;
 
-sub version { return '1.00'; }
+sub version { return '1.01'; }
 
 sub generate_advice {
     my ($self) = @_;
 
-    $self->_check_rpm();
+    $self->_check_rpm() if $self->_distro_uses_rpm();
 
     return 1;
 }
@@ -84,6 +84,21 @@ sub _check_rpm {
     }
 
     return;
+}
+
+sub _distro_uses_rpm {
+    my ($self) = @_;
+
+    # Optimistically try to query Cpanel::OS:
+    my $answer = eval {
+        require Cpanel::OS;
+        Cpanel::OS::is_rpm_based();
+    };
+    return $answer unless $@;
+
+    # cPanel is too old for that to work. Since the rpm program can't be relied
+    # upon, query for the existence of /etc/redhat-release:
+    return -e '/etc/redhat-release';
 }
 
 1;


### PR DESCRIPTION
These commits prevent all invocations of the RPM utility on systems which don't use that as their base package manager.