### PR TITLE
Update link to MultiPHP Manager interface

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/PHP.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/PHP.pm
@@ -86,7 +86,7 @@ sub _check_for_php_eol {
             'text'       => $self->_lh->maketext( '[list_and,_1] reached [output,acronym,EOL,End of Life][comment,title]', \@eol_php_versions ),
             'suggestion' => _make_unordered_list( map { $_->{'text'} } @{ $eol_reco_data->{'options'} } ) . $self->_lh->maketext(
                 'We recommend that you use the [output,url,_1,MultiPHP Manager,_4,_5] interface to upgrade your domains to a supported version. Then, uninstall [numerate,_2,this version,these versions] in the [output,url,_3,EasyApache 4,_4,_5] interface.',
-                $self->base_path('scripts2/multiphp_manager'),
+                $self->base_path('scripts7/multiphp-manager'),
                 scalar @eol_php_versions,
                 $self->base_path('scripts7/EasyApache4'),
                 'target',


### PR DESCRIPTION
Case CPANEL-38967: The MultiPHP Manager interface was converted to an
angular application and had its URI updated as part of the conversion.
However, Security Advisor was not made aware of the new URI and was
still providing the link to the deprecated/removed interface which
resulted in a 404.  This change updates the link to point to the new
URI.

Changelog: Update link to MultiPHP Manager interface